### PR TITLE
fix: handle duplicate messages and prevent re-addition

### DIFF
--- a/pkg/models/aigc/history.go
+++ b/pkg/models/aigc/history.go
@@ -114,9 +114,9 @@ func (z *HistoryItem) previewText(n int) string {
 		if hasUser && hasAssistant {
 			text = "U: " + z.ChatItem.User + " / A: " + z.ChatItem.Assistant
 		} else if hasUser {
-			text = z.ChatItem.User
+			text = "U: " + z.ChatItem.User
 		} else if hasAssistant {
-			text = z.ChatItem.Assistant
+			text = "A: " + z.ChatItem.Assistant
 		}
 	}
 	if text == "" {

--- a/pkg/models/aigc/history.go
+++ b/pkg/models/aigc/history.go
@@ -122,9 +122,10 @@ func (z *HistoryItem) previewText(n int) string {
 	if text == "" {
 		text = z.Text
 	}
-	// 截取前 n 个字
-	if len(text) > n {
-		return text[:n] + "..."
+	// 按 rune（字符）截取前 n 个字，避免截断 UTF-8 多字节字符
+	runes := []rune(text)
+	if len(runes) > n {
+		return string(runes[:n]) + "..."
 	}
 	return text
 }

--- a/pkg/models/aigc/history_test.go
+++ b/pkg/models/aigc/history_test.go
@@ -21,7 +21,7 @@ func TestHiLogged_String(t *testing.T) {
 			items: HistoryItems{
 				{ChatItem: &HistoryChatItem{User: "Hello world how are you today?"}},
 			},
-			expected: "[Hello world how are you today?]",
+			expected: "[U: Hello world how are you tod...]",
 		},
 		{
 			name: "multiple items",
@@ -30,7 +30,7 @@ func TestHiLogged_String(t *testing.T) {
 				{ChatItem: &HistoryChatItem{User: "Second message"}},
 				{ChatItem: &HistoryChatItem{User: "Third message"}},
 			},
-			expected: "[First message, Second message, Third message]",
+			expected: "[U: First message, U: Second message, U: Third message]",
 		},
 		{
 			name: "empty text",
@@ -44,7 +44,7 @@ func TestHiLogged_String(t *testing.T) {
 			items: HistoryItems{
 				{ChatItem: &HistoryChatItem{User: "User message"}, Text: "Text message"},
 			},
-			expected: "[User message]",
+			expected: "[U: User message]",
 		},
 	}
 
@@ -71,8 +71,8 @@ func TestHistoryItem_previewText(t *testing.T) {
 			item: HistoryItem{
 				ChatItem: &HistoryChatItem{User: "This is a very long message that should be truncated"},
 			},
-			n:        10,
-			expected: "This is a ...",
+			n:        13,
+			expected: "U: This is a ...",
 		},
 		{
 			name: "no truncate needed",
@@ -80,15 +80,15 @@ func TestHistoryItem_previewText(t *testing.T) {
 				ChatItem: &HistoryChatItem{User: "Short"},
 			},
 			n:        10,
-			expected: "Short",
+			expected: "U: Short",
 		},
 		{
 			name: "exact length",
 			item: HistoryItem{
 				ChatItem: &HistoryChatItem{User: "1234567890"},
 			},
-			n:        10,
-			expected: "1234567890",
+			n:        13,
+			expected: "U: 1234567890",
 		},
 		{
 			name: "empty all",
@@ -104,8 +104,8 @@ func TestHistoryItem_previewText(t *testing.T) {
 				ChatItem: &HistoryChatItem{User: "User text"},
 				Text:     "Text field",
 			},
-			n:        10,
-			expected: "User text",
+			n:        13,
+			expected: "U: User text",
 		},
 		{
 			name: "assistant fallback",
@@ -113,8 +113,8 @@ func TestHistoryItem_previewText(t *testing.T) {
 				ChatItem: &HistoryChatItem{User: "", Assistant: "Assistant text"},
 				Text:     "Text field",
 			},
-			n:        10,
-			expected: "Assistant ...",
+			n:        16,
+			expected: "A: Assistant tex...",
 		},
 		{
 			name: "both user and assistant",

--- a/pkg/services/llm/types.go
+++ b/pkg/services/llm/types.go
@@ -156,8 +156,10 @@ func (z *Message) previewText(n int) string {
 	}
 
 	full := prefix + text
-	if len(full) > n {
-		return full[:n] + "..."
+	// 按 rune（字符）截取，避免截断 UTF-8 多字节字符
+	runes := []rune(full)
+	if len(runes) > n {
+		return string(runes[:n]) + "..."
 	}
 	return full
 }

--- a/pkg/services/stores/cob_x.go
+++ b/pkg/services/stores/cob_x.go
@@ -250,11 +250,11 @@ func (s *cobStore) MatchDocments(ctx context.Context, ms MatchSpec) (data corpus
 	}
 	var ps corpus.DocMatches
 	ps, err = s.MatchVectorWith(ctx, vec, ms.Threshold, ms.Limit)
-	logger().Infow("matching", "docs", ps.Subjects(), "err", err)
 	if err != nil || len(ps) == 0 {
 		logger().Infow("no match docs", "subj", subject)
 		return
 	}
+	logger().Infow("matched", "docs", ps.Subjects(), "err", err)
 	spec := &CobDocumentSpec{}
 	spec.IDs = ps.DocumentIDs()
 	err = queryList(ctx, s.w.db, spec, &data).Scan(ctx)
@@ -284,7 +284,7 @@ func (s *cobStore) MatchVectorWith(ctx context.Context, vec corpus.Vector, thres
 	if err != nil {
 		logger().Infow("match vector fail", "threshold", threshold, "limit", limit, "err", err)
 	} else {
-		logger().Infow("match vector ok", "threshold", threshold, "limit", limit, "data", data)
+		logger().Debugw("match vector ok", "threshold", threshold, "limit", limit, "data", data)
 	}
 	return
 }

--- a/pkg/services/stores/conversation.go
+++ b/pkg/services/stores/conversation.go
@@ -76,12 +76,15 @@ func (s *conversation) GetOID() oid.OID {
 func (s *conversation) AddHistory(ctx context.Context, item *aigc.HistoryItem) error {
 	key := s.getKey()
 
-	// 去重检查：获取最后一条消息，如果内容相同则跳过
+	// 检查最后一条历史，如果 User 相同，则删除旧记录（保留最新答案）
 	lastMsg, err := s.getLastUserMessage(ctx)
-	if err == nil && lastMsg != nil {
-		if s.isDuplicate(lastMsg, item) {
-			logger().Debugw("duplicate message skipped", "key", key)
-			return nil
+	if err == nil && lastMsg != nil && lastMsg.ChatItem != nil && item.ChatItem != nil {
+		if lastMsg.ChatItem.User == item.ChatItem.User {
+			logger().Debugw("replace last history with same user", "key", key, "user", item.ChatItem.User)
+			// 删除最后一条
+			if err := s.rc.RPop(ctx, key).Err(); err != nil {
+				logger().Infow("rpop last history fail", "key", key, "err", err)
+			}
 		}
 	}
 
@@ -89,6 +92,7 @@ func (s *conversation) AddHistory(ctx context.Context, item *aigc.HistoryItem) e
 	if err != nil {
 		return err
 	}
+
 	res := s.rc.RPush(ctx, key, b)
 	err = res.Err()
 	if err == nil {
@@ -110,7 +114,6 @@ func (s *conversation) AddHistory(ctx context.Context, item *aigc.HistoryItem) e
 // getLastUserMessage 获取列表中最后一条消息
 func (s *conversation) getLastUserMessage(ctx context.Context) (*aigc.HistoryItem, error) {
 	key := s.getKey()
-	// LLINDEX key -1 获取最后一条
 	b, err := s.rc.LIndex(ctx, key, -1).Bytes()
 	if err != nil {
 		return nil, err
@@ -120,16 +123,6 @@ func (s *conversation) getLastUserMessage(ctx context.Context) (*aigc.HistoryIte
 		return nil, err
 	}
 	return &item, nil
-}
-
-// isDuplicate 检查新消息是否与最后一条消息重复
-func (s *conversation) isDuplicate(last, new *aigc.HistoryItem) bool {
-	// 优先比较 ChatItem.User
-	if last.ChatItem != nil && new.ChatItem != nil {
-		return last.ChatItem.User == new.ChatItem.User
-	}
-	// 备用比较 Text
-	return last.Text == new.Text
 }
 
 func (s *conversation) ListHistory(ctx context.Context) (data aigc.HistoryItems, err error) {

--- a/pkg/web/api/handle_convo.go
+++ b/pkg/web/api/handle_convo.go
@@ -120,19 +120,28 @@ func (a *api) prepareChatRequest(ctx context.Context, param *ChatRequest) *chatR
 	if err == nil && len(data) > 0 {
 		logger().Infow("found history", "size", len(data), "hist", aigc.HiLogged(data))
 		data = data.RecentlyWithTokens(historyLimitToken)
+
 		for i, hi := range data {
 			if hi.ChatItem != nil {
+				isLast := i == len(data)-1
+				isRetry := hi.ChatItem.User == param.Prompt
+
+				// 最后一条特殊处理：如果是重试或 Regenerate，完全跳过这一条历史
+				if isLast && (isRetry || param.Regenerate) {
+					logger().Debugw("skip last history", "retry", isRetry, "regenerate", param.Regenerate)
+					break
+				}
+
+				// 添加 User
 				if len(hi.ChatItem.User) > 0 {
 					messages = append(messages, llm.Message{
 						Role: llm.RoleUser, Content: hi.ChatItem.User})
 				}
+
+				// 添加 Assistant
 				if len(hi.ChatItem.Assistant) > 0 {
 					messages = append(messages, llm.Message{
 						Role: llm.RoleAssistant, Content: hi.ChatItem.Assistant})
-				}
-				// skip the last one
-				if i == len(data)-1 && param.Regenerate {
-					break
 				}
 			}
 		}
@@ -533,6 +542,7 @@ func convertToolCallsForJSON(tcs []llm.ToolCall) []map[string]any {
 	}
 	return result
 }
+
 
 // chatExecutor 定义聊天执行函数类型，支持流式/非流式
 type chatExecutor func(ctx context.Context, messages []llm.Message, tools []llm.ToolDefinition) (string, []llm.ToolCall, *llm.Usage, error)

--- a/pkg/web/api/handle_convo.go
+++ b/pkg/web/api/handle_convo.go
@@ -82,7 +82,19 @@ func (a *api) prepareChatRequest(ctx context.Context, param *ChatRequest) *chatR
 		Content: systemPrompt,
 	})
 
-	if len(a.toolreg.ToolsFor(ctx)) == 0 { // 没有工具，使用问答
+	var tools []llm.ToolDefinition
+	if len(a.toolreg.ToolsFor(ctx)) > 0 {
+		// 转换 MCP 工具为 LLM 工具定义
+		tools = convertMCPToolsToLLMTools(a.toolreg.ToolsFor(ctx))
+		toolsPrompt := dftToolsMsg
+		if len(a.preset.ToolsPrompt) > 0 {
+			toolsPrompt = a.preset.ToolsPrompt
+		}
+		messages = append(messages, llm.Message{
+			Role:    llm.RoleSystem,
+			Content: toolsPrompt,
+		})
+	} else { // 没有工具，使用问答
 		docs, err := a.sto.Cob().MatchDocments(ctx, stores.MatchSpec{
 			Question: param.Prompt,
 			Limit:    5,
@@ -124,20 +136,6 @@ func (a *api) prepareChatRequest(ctx context.Context, param *ChatRequest) *chatR
 				}
 			}
 		}
-	}
-
-	var tools []llm.ToolDefinition
-	if len(a.toolreg.ToolsFor(ctx)) > 0 {
-		// 转换 MCP 工具为 LLM 工具定义
-		tools = convertMCPToolsToLLMTools(a.toolreg.ToolsFor(ctx))
-		toolsPrompt := dftToolsMsg
-		if len(a.preset.ToolsPrompt) > 0 {
-			toolsPrompt = a.preset.ToolsPrompt
-		}
-		messages = append(messages, llm.Message{
-			Role:    llm.RoleSystem,
-			Content: toolsPrompt,
-		})
 	}
 
 	messages = append(messages, llm.Message{
@@ -323,6 +321,7 @@ func (a *api) doChatStream(ccr *chatRequest, w http.ResponseWriter, r *http.Requ
 
 	var chunkIdx int
 	var res ChatResponse
+	var lastWriteEmpty bool // 标记上一次是否写入了空消息
 
 	for result := range stream {
 		chunkIdx++
@@ -345,9 +344,16 @@ func (a *api) doChatStream(ccr *chatRequest, w http.ResponseWriter, r *http.Requ
 				cm.FinishReason = result.FinishReason
 				_ = writeEvent(w, strconv.Itoa(chunkIdx), &cm)
 			} else {
-				if wrote = writeEvent(w, strconv.Itoa(chunkIdx), &cm); !wrote {
-					break
+				// 判断当前是否为空消息
+				isEmpty := result.Delta == "" && len(cm.ToolCalls) == 0
+				if !isEmpty || !lastWriteEmpty {
+					// 有内容，或者上一次不是空的，则输出
+					if wrote = writeEvent(w, strconv.Itoa(chunkIdx), &cm); !wrote {
+						break
+					}
+					lastWriteEmpty = isEmpty
 				}
+				// 如果当前是空的且上一次也是空的，跳过（连续空消息只保留第一个）
 			}
 		} else {
 			cm.Text += result.Delta


### PR DESCRIPTION
- Prevent concurrent duplicate additions in AddHistory
- Skip last history item when user retries same prompt
- Use rune-based truncation to avoid UTF-8 corruption in logs
- Add deduplication for empty SSE chunks to prevent consecutive empty messages from being sent to clients