### PR TITLE
feat(wecom): add streaming message support with StreamReplier interface

### DIFF
--- a/docs/plans/2026-04-02-004-feat-wecom-streaming-messages-plan.md
+++ b/docs/plans/2026-04-02-004-feat-wecom-streaming-messages-plan.md
@@ -1,0 +1,186 @@
+---
+title: feat: WeCom WebSocket 流式消息支持
+type: feat
+status: active
+date: 2026-04-02
+---
+
+# WeCom WebSocket 流式消息支持
+
+## Overview
+
+改造 WeCom WebSocket 的 `Reply` 方法，实现真正的流式消息：首次 `finish=false` 创建流，后续追加，最终 `finish=true` 结束。
+
+## Problem Statement
+
+当前 `WSChannel.Reply()` (`websocket.go:370`) 直接发送 `finish=true` 的流式消息，无法实现内容接续效果。
+
+## Proposed Solution
+
+### 1. WSChannel 添加三个方法
+
+在 `pkg/services/channels/wecom/websocket.go` 中新增：
+
+```go
+// startStream 首次发送，finish=false
+func (p *WSChannel) startStream(ctx context.Context, rctx wsReplyContext, content string) (string, error) {
+    streamID := p.generateReqID("stream")
+    frame := p.buildStreamFrame(rctx, streamID, content, false)
+    if err := p.writeJSON(frame); err != nil {
+        return "", err
+    }
+    return streamID, nil
+}
+
+// appendStream 后续发送，finish=false
+func (p *WSChannel) appendStream(ctx context.Context, rctx wsReplyContext, streamID string, content string) error {
+    frame := p.buildStreamFrame(rctx, streamID, content, false)
+    return p.writeJSON(frame)
+}
+
+// finishStream 结束发送，finish=true
+func (p *WSChannel) finishStream(ctx context.Context, rctx wsReplyContext, streamID string) error {
+    frame := p.buildStreamFrame(rctx, streamID, "", true)
+    return p.writeJSON(frame)
+}
+
+// wsStreamFrame 预定义流式消息帧结构
+type wsStreamFrame struct {
+    Cmd     string         `json:"cmd"`
+    Headers wsFrameHeaders `json:"headers"`
+    Body    wsStreamBody   `json:"body"`
+}
+
+type wsStreamBody struct {
+    MsgType string        `json:"msgtype"`
+    Stream  wsStreamContent `json:"stream"`
+}
+
+type wsStreamContent struct {
+    ID      string `json:"id"`
+    Finish  bool   `json:"finish"`
+    Content string `json:"content"`
+}
+
+func (p *WSChannel) buildStreamFrame(rc wsReplyContext, streamID, content string, finish bool) wsStreamFrame {
+    return wsStreamFrame{
+        Cmd:     "aibot_respond_msg",
+        Headers: wsFrameHeaders{ReqID: rc.reqID},
+        Body: wsStreamBody{
+            MsgType: "stream",
+            Stream: wsStreamContent{
+                ID:      streamID,
+                Finish:  finish,
+                Content: content,
+            },
+        },
+    }
+}
+```
+
+### 2. StreamReplier 接口（可选）
+
+在 `pkg/models/channel/channel.go` 添加：
+
+```go
+// StreamReplier is an optional interface for channels that support streaming.
+type StreamReplier interface {
+    StartStream(ctx context.Context, replyCtx any, content string) (streamID string, err error)
+    AppendStream(ctx context.Context, replyCtx any, streamID string, content string) error
+    FinishStream(ctx context.Context, replyCtx any, streamID string) error
+}
+```
+
+WSChannel 实现该接口。
+
+### 3. MessageHandler 流式分支
+
+在 `handle_platform.go` 中检测 `StreamReplier` 接口，走流式处理分支：
+
+```go
+// handleStreamingReply 处理 WeCom WebSocket 流式回复
+func (chh *channelHandler) handleStreamingReply(p channel.Channel, msg *channel.Message) {
+    ctx := context.Background()
+
+    // 构建消息（复用现有逻辑）...
+    messages, tools := chh.buildChatMessages(msg)
+
+    // 流式调用 LLM
+    stream, err := chh.llm.StreamChat(ctx, messages, tools)
+    if err != nil {
+        channelReplyError(p, msg, "AI processing failed")
+        return
+    }
+
+    sr := p.(channel.StreamReplier)
+    var streamID string
+    var content strings.Builder // 本地累积完整内容
+
+    for result := range stream {
+        if result.Error != nil {
+            slog.Warn("channel: stream error", "err", result.Error)
+            break
+        }
+
+        content.WriteString(result.Delta) // 累积内容
+
+        if streamID == "" {
+            // 首次：startStream，发送累积内容
+            sid, err := sr.StartStream(ctx, msg.ReplyCtx, content.String())
+            if err != nil {
+                slog.Error("channel: start stream failed", "err", err)
+                channelReplyError(p, msg, "Failed to start streaming")
+                return
+            }
+            streamID = sid
+        } else {
+            // 后续：appendStream，每次发送完整累积内容（覆盖更新）
+            if err := sr.AppendStream(ctx, msg.ReplyCtx, streamID, content.String()); err != nil {
+                slog.Warn("channel: append stream failed", "err", err)
+            }
+        }
+    }
+
+    // 结束流
+    if streamID != "" {
+        if err := sr.FinishStream(ctx, msg.ReplyCtx, streamID); err != nil {
+            slog.Warn("channel: finish stream failed", "err", err)
+        }
+    }
+
+    // 保存历史...
+}
+```
+
+`MessageHandler` 中检测：
+
+```go
+func (chh *channelHandler) MessageHandler(p channel.Channel, msg *channel.Message) {
+    // ... 命令检测等前置逻辑不变 ...
+
+    if sr, ok := p.(channel.StreamReplier); ok {
+        chh.handleStreamingReply(p, msg)
+    } else {
+        chh.handleRegularReply(p, msg)
+    }
+}
+```
+
+## File Changes
+
+| File | Change |
+|------|--------|
+| `pkg/models/channel/channel.go` | 添加 `StreamReplier` 接口 |
+| `pkg/services/channels/wecom/websocket.go` | 实现 `StreamReplier` 三个方法 |
+| `pkg/web/api/handle_platform.go` | `MessageHandler` 增加流式分支检测 |
+
+## Acceptance Criteria
+
+- [ ] WeCom WebSocket 首次发送 `finish=false`
+- [ ] 后续增量追加
+- [ ] 最终发送 `finish=true`
+- [ ] HTTP 模式和其他通道不受影响
+
+## ⚠️ 待验证
+
+- [x] ~~**WeCom 流式接续语义**~~ 官方文档明确：继续使用相同 `stream.id` 推送会**覆盖**消息内容，需本地累积完整内容后发送。设计已按此思路实现，验证不符时再修订。

--- a/pkg/models/channel/channel.go
+++ b/pkg/models/channel/channel.go
@@ -46,5 +46,13 @@ type MessageUpdater interface {
 	UpdateMessage(ctx context.Context, replyCtx any, content string) error
 }
 
+// StreamReplier is an optional interface for channels that support streaming message updates.
+// The channel accumulates content locally and sends full accumulated content on each update.
+type StreamReplier interface {
+	StartStream(ctx context.Context, replyCtx any, content string) (streamID string, err error)
+	AppendStream(ctx context.Context, replyCtx any, streamID string, content string) error
+	FinishStream(ctx context.Context, replyCtx any, streamID string, finalContent string) error
+}
+
 // MessageHandler is called by channels when a new message arrives.
 type MessageHandler func(p Channel, msg *Message)

--- a/pkg/services/channels/wecom/websocket.go
+++ b/pkg/services/channels/wecom/websocket.go
@@ -80,6 +80,24 @@ type wsMsgCallbackBody struct {
 	CreateTime int64 `json:"create_time"`
 }
 
+// wsStreamFrame is the frame structure for streaming message responses.
+type wsStreamFrame struct {
+	Cmd     string         `json:"cmd"`
+	Headers wsFrameHeaders `json:"headers"`
+	Body    wsStreamBody   `json:"body"`
+}
+
+type wsStreamBody struct {
+	MsgType string          `json:"msgtype"`
+	Stream  wsStreamContent `json:"stream"`
+}
+
+type wsStreamContent struct {
+	ID      string `json:"id"`
+	Finish  bool   `json:"finish"`
+	Content string `json:"content"`
+}
+
 func newWebSocket(opts map[string]any) (channel.Channel, error) {
 	botID, _ := opts["bot_id"].(string)
 	secret, _ := opts["bot_secret"].(string)
@@ -98,9 +116,15 @@ func newWebSocket(opts map[string]any) (channel.Channel, error) {
 
 func (p *WSChannel) generateReqID(prefix string) string {
 	id := oid.NewID(oid.OtEvent)
-	return id.String()
-	// seq := p.reqSeq.Add(1)
-	// return fmt.Sprintf("%s_%d", prefix, seq)
+	return fmt.Sprintf("%s_%s", prefix, id)
+}
+
+func (p *WSChannel) replyCtx(rctx any) (wsReplyContext, error) {
+	rc, ok := rctx.(wsReplyContext)
+	if !ok {
+		return wsReplyContext{}, fmt.Errorf("wecom-ws: invalid reply context type %T", rctx)
+	}
+	return rc, nil
 }
 
 func (p *WSChannel) Name() string { return "wecom" }
@@ -368,39 +392,82 @@ func (p *WSChannel) handleMsgCallback(frame wsFrame) {
 }
 
 func (p *WSChannel) Reply(ctx context.Context, rctx any, content string) error {
-	rc, ok := rctx.(wsReplyContext)
-	if !ok {
-		return fmt.Errorf("wecom-ws: invalid reply context type %T", rctx)
-	}
 	if content == "" {
 		return nil
 	}
+	streamID, err := p.StartStream(ctx, rctx, content)
+	if err != nil {
+		return err
+	}
+	return p.FinishStream(ctx, rctx, streamID, content)
+}
 
-	streamID := p.generateReqID("stream")
-	frame := map[string]any{
-		"cmd":     "aibot_respond_msg",
-		"headers": map[string]string{"req_id": rc.reqID},
-		"body": map[string]any{
-			"msgtype": "stream",
-			"stream": map[string]any{
-				"id":      streamID,
-				"finish":  true,
-				"content": content,
+// buildStreamFrame builds a streaming message frame.
+func (p *WSChannel) buildStreamFrame(rc wsReplyContext, streamID, content string, finish bool) wsStreamFrame {
+	return wsStreamFrame{
+		Cmd:     "aibot_respond_msg",
+		Headers: wsFrameHeaders{ReqID: rc.reqID},
+		Body: wsStreamBody{
+			MsgType: "stream",
+			Stream: wsStreamContent{
+				ID:      streamID,
+				Finish:  finish,
+				Content: content,
 			},
 		},
 	}
+}
+
+// StartStream starts a new streaming message, returns the stream ID.
+func (p *WSChannel) StartStream(ctx context.Context, rctx any, content string) (string, error) {
+	rc, err := p.replyCtx(rctx)
+	if err != nil {
+		return "", err
+	}
+	streamID := p.generateReqID("stream")
+	frame := p.buildStreamFrame(rc, streamID, content, false)
 	if err := p.writeJSON(frame); err != nil {
-		slog.Error("wecom-ws: reply failed", "user", rc.userID, "error", err)
+		slog.Error("wecom-ws: start stream failed", "user", rc.userID, "error", err)
+		return "", err
+	}
+	slog.Debug("wecom-ws: stream started", "user", rc.userID, "streamID", streamID, "len", len(content))
+	return streamID, nil
+}
+
+// AppendStream appends content to an existing stream.
+func (p *WSChannel) AppendStream(ctx context.Context, rctx any, streamID string, content string) error {
+	rc, err := p.replyCtx(rctx)
+	if err != nil {
 		return err
 	}
-	slog.Debug("wecom-ws: reply sent", "user", rc.userID, "len", len(content))
+	frame := p.buildStreamFrame(rc, streamID, content, false)
+	if err := p.writeJSON(frame); err != nil {
+		slog.Warn("wecom-ws: append stream failed", "user", rc.userID, "streamID", streamID, "error", err)
+		return err
+	}
+	slog.Debug("wecom-ws: stream appended", "user", rc.userID, "streamID", streamID, "len", len(content))
+	return nil
+}
+
+// FinishStream ends the streaming message with final content.
+func (p *WSChannel) FinishStream(ctx context.Context, rctx any, streamID string, finalContent string) error {
+	rc, err := p.replyCtx(rctx)
+	if err != nil {
+		return err
+	}
+	frame := p.buildStreamFrame(rc, streamID, finalContent, true)
+	if err := p.writeJSON(frame); err != nil {
+		slog.Error("wecom-ws: finish stream failed", "user", rc.userID, "streamID", streamID, "error", err)
+		return err
+	}
+	slog.Debug("wecom-ws: stream finished", "user", rc.userID, "streamID", streamID, "content_len", len(finalContent))
 	return nil
 }
 
 func (p *WSChannel) Send(ctx context.Context, rctx any, content string) error {
-	rc, ok := rctx.(wsReplyContext)
-	if !ok {
-		return fmt.Errorf("wecom-ws: invalid reply context type %T", rctx)
+	rc, err := p.replyCtx(rctx)
+	if err != nil {
+		return err
 	}
 	if content == "" {
 		return nil

--- a/pkg/web/api/handle_platform.go
+++ b/pkg/web/api/handle_platform.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -13,6 +15,7 @@ import (
 	"github.com/liut/morign/pkg/services/llm"
 	"github.com/liut/morign/pkg/services/stores"
 	"github.com/liut/morign/pkg/services/tools"
+	"github.com/liut/morign/pkg/settings"
 )
 
 // channelHandler holds dependencies for handling channel messages.
@@ -137,35 +140,220 @@ func (chh *channelHandler) MessageHandler(p channel.Channel, msg *channel.Messag
 		"content_len", len(msg.Content),
 	)
 
-	// Prepare system message and tools
-	sysMsg, tools := prepareSystemMessage(ctx, chh.sto, chh.toolreg, msg.Content, cs)
-
-	// Build user message with any attachments
-	content := msg.Content
-	if len(msg.Images) > 0 {
-		content += "\n[User sent an image]"
+	// Detect streaming support
+	if sr, ok := p.(channel.StreamReplier); ok {
+		chh.handleStreamingReply(ctx, p, msg, sr, cs)
+	} else {
+		chh.handleRegularReply(ctx, p, msg, cs)
 	}
-	if msg.Audio != nil {
-		content += "\n[User sent a voice message]"
+}
+
+// handleStreamingReply handles reply with streaming support (e.g., WeCom WebSocket).
+// It uses a loop similar to chatStreamResponseLoop to handle tool calls.
+func (chh *channelHandler) handleStreamingReply(ctx context.Context, p channel.Channel, msg *channel.Message, sr channel.StreamReplier, cs stores.Conversation) {
+	// Build messages and get tools
+	messages, tools := chh.buildChatMessagesAndTools(ctx, msg, cs)
+
+	// MaxLoopIterations limits tool call chain depth to prevent infinite loops (default: 5)
+	maxLoopIterations := settings.Current.MaxLoopIterations
+	iter := 0
+	var fullAnswer string
+	var streamID string
+
+	for {
+		iter++
+		if iter > maxLoopIterations {
+			slog.Info("channel: streaming loop iteration limit reached", "maxIter", maxLoopIterations)
+			break
+		}
+
+		// Do one streaming round
+		answer, toolCalls, newStreamID, err := chh.doChannelStream(ctx, p, msg, sr, messages, tools)
+		if err != nil {
+			channelReplyError(p, msg, "AI processing failed")
+			return
+		}
+		slog.Info("channel: stream round done",
+			"iter", iter,
+			"answer_len", len(answer),
+			"toolCalls_len", len(toolCalls),
+			"newStreamID", newStreamID,
+			"streamID", streamID)
+
+		// Only update fullAnswer if we got actual content
+		if answer != "" {
+			fullAnswer = answer
+		}
+		// Only set streamID if we don't have one yet
+		if streamID == "" && newStreamID != "" {
+			streamID = newStreamID
+		}
+
+		// No more tool calls, we're done
+		if len(toolCalls) == 0 {
+			break
+		}
+
+		// Add assistant response to messages (with full answer content)
+		if fullAnswer != "" {
+			messages = append(messages, llm.Message{Role: llm.RoleAssistant, Content: fullAnswer})
+		}
+
+		// Execute tool calls and update messages with results
+		var hasToolCall bool
+		messages, hasToolCall = chh.executeChannelToolCalls(ctx, messages, toolCalls)
+		if !hasToolCall {
+			break
+		}
 	}
 
-	// Load conversation history
-	messages := []llm.Message{sysMsg}
-	history, _ := cs.ListHistory(ctx)
-	for _, hi := range history {
-		if hi.ChatItem != nil {
-			if hi.ChatItem.User != "" {
-				messages = append(messages, llm.Message{Role: llm.RoleUser, Content: hi.ChatItem.User})
-			}
-			if hi.ChatItem.Assistant != "" {
-				messages = append(messages, llm.Message{Role: llm.RoleAssistant, Content: hi.ChatItem.Assistant})
+	slog.Info("channel: streaming reply finishing",
+		"streamID", streamID,
+		"fullAnswer_len", len(fullAnswer))
+
+	// Finish the stream
+	if streamID != "" {
+		if err := sr.FinishStream(ctx, msg.ReplyCtx, streamID, fullAnswer); err != nil {
+			slog.Warn("channel: finish stream failed", "err", err)
+		}
+	} else if fullAnswer != "" {
+		// Edge case: stream was never started but we have content
+		// This shouldn't normally happen, but handle it gracefully
+		slog.Warn("channel: stream not started, using Reply instead")
+		if err := p.Reply(ctx, msg.ReplyCtx, fullAnswer); err != nil {
+			slog.Error("channel: fallback reply failed", "err", err)
+		}
+	}
+
+	// Save to history
+	if fullAnswer != "" {
+		hi := &aigc.HistoryItem{
+			Time: time.Now().Unix(),
+			UID:  msg.UserID,
+			ChatItem: &aigc.HistoryChatItem{
+				User:      msg.Content,
+				Assistant: fullAnswer,
+			},
+		}
+		if err := cs.AddHistory(ctx, hi); err == nil {
+			if err := cs.Save(ctx); err != nil {
+				slog.Warn("channel: save history failed", "err", err)
 			}
 		}
 	}
+}
+
+// doChannelStream performs one streaming chat round, returns answer, tool calls, and streamID.
+func (chh *channelHandler) doChannelStream(ctx context.Context, p channel.Channel, msg *channel.Message, sr channel.StreamReplier, messages []llm.Message, tools []llm.ToolDefinition) (string, []llm.ToolCall, string, error) {
+	stream, err := chh.llm.StreamChat(ctx, messages, tools)
+	if err != nil {
+		slog.Error("channel: stream chat failed", "channel", p.Name(), "error", err)
+		return "", nil, "", err
+	}
+
+	var contentBuilder strings.Builder
+	var currentToolCalls []llm.ToolCall
+	var currentStreamID string
+	chunkCount := 0
+
+	for result := range stream {
+		chunkCount++
+		if result.Error != nil {
+			slog.Warn("channel: stream error", "err", result.Error)
+			break
+		}
+
+		contentBuilder.WriteString(result.Delta)
+
+		// Only send to channel when we have content
+		if result.Delta != "" {
+			content := contentBuilder.String()
+			if currentStreamID == "" {
+				sid, err := sr.StartStream(ctx, msg.ReplyCtx, content)
+				if err != nil {
+					slog.Error("channel: start stream failed", "err", err)
+					return "", nil, "", err
+				}
+				currentStreamID = sid
+				slog.Debug("channel: stream started", "streamID", sid, "content_len", len(content))
+			} else {
+				if err := sr.AppendStream(ctx, msg.ReplyCtx, currentStreamID, content); err != nil {
+					slog.Warn("channel: append stream failed", "err", err)
+				}
+			}
+		}
+
+		// Capture tool calls when Done=true (LLM signaled end with tool calls)
+		if result.Done {
+			currentToolCalls = result.ToolCalls
+			slog.Debug("channel: stream Done received", "toolCalls_len", len(result.ToolCalls))
+		}
+	}
+
+	slog.Info("channel: doChannelStream result",
+		"chunkCount", chunkCount,
+		"content_len", contentBuilder.Len(),
+		"toolCalls_len", len(currentToolCalls),
+		"streamID", currentStreamID)
+
+	// Stream ended (EOF). If Done was never true, there are no tool calls.
+	// currentToolCalls remains nil, which is correct.
+	return contentBuilder.String(), currentToolCalls, currentStreamID, nil
+}
+
+// executeChannelToolCalls executes tool calls and appends results to messages.
+// Returns updated messages slice and whether any tool was successfully executed.
+func (chh *channelHandler) executeChannelToolCalls(ctx context.Context, messages []llm.Message, toolCalls []llm.ToolCall) ([]llm.Message, bool) {
+	slog.Info("channel: executing tool calls", "count", len(toolCalls))
+
+	if len(toolCalls) == 0 {
+		return messages, false
+	}
+
+	// First append the assistant message with tool calls
 	messages = append(messages, llm.Message{
-		Role:    llm.RoleUser,
-		Content: content,
+		Role:      llm.RoleAssistant,
+		ToolCalls: toolCalls,
 	})
+
+	hasToolCall := false
+	for _, tc := range toolCalls {
+		if tc.Type != "function" {
+			continue
+		}
+
+		var parameters map[string]any
+		args := string(tc.Function.Arguments)
+		if args != "" && args != "{}" {
+			if err := json.Unmarshal(tc.Function.Arguments, &parameters); err != nil {
+				slog.Warn("channel: unmarshal tool args failed", "err", err)
+				continue
+			}
+		}
+		if parameters == nil {
+			parameters = make(map[string]any)
+		}
+
+		content, err := chh.toolreg.Invoke(ctx, tc.Function.Name, parameters)
+		if err != nil {
+			slog.Warn("channel: invoke tool failed", "tool", tc.Function.Name, "err", err)
+			continue
+		}
+
+		messages = append(messages, llm.Message{
+			Role:       llm.RoleTool,
+			Content:    formatToolResult(content),
+			ToolCallID: tc.ID,
+		})
+		hasToolCall = true
+	}
+
+	return messages, hasToolCall
+}
+
+// handleRegularReply handles reply without streaming (non-WebSocket channels).
+func (chh *channelHandler) handleRegularReply(ctx context.Context, p channel.Channel, msg *channel.Message, cs stores.Conversation) {
+	messages, tools := chh.buildChatMessagesAndTools(ctx, msg, cs)
 
 	// Execute the chat with tool call loop
 	exec := func(ctx context.Context, messages []llm.Message, tools []llm.ToolDefinition) (string, []llm.ToolCall, *llm.Usage, error) {
@@ -219,4 +407,33 @@ func channelReplyError(p channel.Channel, msg *channel.Message, errorText string
 		slog.Error("channel: send error reply failed",
 			"channel", p.Name(), "error", err)
 	}
+}
+
+// buildChatMessagesAndTools builds the message list and returns tools for the chat.
+func (chh *channelHandler) buildChatMessagesAndTools(ctx context.Context, msg *channel.Message, cs stores.Conversation) ([]llm.Message, []llm.ToolDefinition) {
+	sysMsg, tools := prepareSystemMessage(ctx, chh.sto, chh.toolreg, msg.Content, cs)
+
+	content := msg.Content
+	if len(msg.Images) > 0 {
+		content += "\n[User sent an image]"
+	}
+	if msg.Audio != nil {
+		content += "\n[User sent a voice message]"
+	}
+
+	messages := []llm.Message{sysMsg}
+	history, _ := cs.ListHistory(ctx)
+	for _, hi := range history {
+		if hi.ChatItem != nil {
+			if hi.ChatItem.User != "" {
+				messages = append(messages, llm.Message{Role: llm.RoleUser, Content: hi.ChatItem.User})
+			}
+			if hi.ChatItem.Assistant != "" {
+				messages = append(messages, llm.Message{Role: llm.RoleAssistant, Content: hi.ChatItem.Assistant})
+			}
+		}
+	}
+	messages = append(messages, llm.Message{Role: llm.RoleUser, Content: content})
+
+	return messages, tools
 }


### PR DESCRIPTION
- Add StreamReplier interface for channels supporting streaming (StartStream, AppendStream, FinishStream)
- Implement streaming methods in WSChannel with full accumulated content updates
- Reply now delegates to StartStream + FinishStream (DRY)
- Extract replyCtx helper to eliminate type assertion duplication
- generateReqID now uses prefix format (prefix_id)
- Add handleStreamingReply with tool call loop support
- Use settings.Current.MaxLoopIterations for loop limit
- Extract buildChatMessagesAndTools to eliminate code duplication