### PR TITLE
feat(llm): add per-provider interaction logging to file

### DIFF
--- a/pkg/services/llm/anthropic.go
+++ b/pkg/services/llm/anthropic.go
@@ -97,7 +97,22 @@ func (p *anthropicProvider) Chat(ctx context.Context, cfg *config, messages []Me
 		return nil, errMsg
 	}
 
-	return parseAnthropicResponse(body)
+	result, err := parseAnthropicResponse(body)
+	if err != nil {
+		return nil, err
+	}
+	// 写入交互日志
+	if cfg.logDir != "" {
+		go LogInteraction(cfg.logDir, "anthropic", &InteractionLog{
+			Model:     cfg.model,
+			Messages:  messages,
+			Tools:     tools,
+			Usage:     result.Usage,
+			Response:  result.Content,
+			ToolCalls: result.ToolCalls,
+		})
+	}
+	return result, nil
 }
 
 func (p *anthropicProvider) StreamChat(ctx context.Context, cfg *config, messages []Message, tools []ToolDefinition) (<-chan StreamResult, error) {
@@ -199,7 +214,7 @@ func (p *anthropicProvider) StreamChat(ctx context.Context, cfg *config, message
 		defer resp.Body.Close()
 
 		// 解析流响应
-		if err := p.parseStreamResponse(resp.Body, ch, cfg.debug); err != nil {
+		if err := p.parseStreamResponse(resp.Body, ch, cfg.debug, cfg.logDir, cfg.model, messages, tools); err != nil {
 			ch <- StreamResult{Error: err}
 		}
 	}()
@@ -208,9 +223,10 @@ func (p *anthropicProvider) StreamChat(ctx context.Context, cfg *config, message
 }
 
 // parseStreamResponse 解析流式响应
-func (p *anthropicProvider) parseStreamResponse(body io.Reader, ch chan<- StreamResult, debug bool) error {
+func (p *anthropicProvider) parseStreamResponse(body io.Reader, ch chan<- StreamResult, debug bool, logDir, model string, messages []Message, tools []ToolDefinition) error {
 	var currentToolCalls []ToolCall
 	var currentText strings.Builder
+	var thinkContent string
 
 	bufReader := bufio.NewReaderSize(body, 1024)
 
@@ -253,7 +269,7 @@ func (p *anthropicProvider) parseStreamResponse(body io.Reader, ch chan<- Stream
 		// logger().Debugw("stream event parsed", "type", event.Type, "index", event.Index,
 		// 	"delta", &event.Delta)
 
-		done, toolCalls := p.handleStreamEvent(event, &currentText, currentToolCalls, ch)
+		done, toolCalls := p.handleStreamEvent(event, &currentText, currentToolCalls, ch, logDir, model, messages, tools, &thinkContent)
 		currentToolCalls = toolCalls
 
 		if done {
@@ -318,7 +334,7 @@ func (p *anthropicProvider) parseStreamEvent(data []byte) (streamEvent, error) {
 }
 
 // handleStreamEvent 处理流事件，返回是否结束及更新后的 toolCalls
-func (p *anthropicProvider) handleStreamEvent(event streamEvent, currentText *strings.Builder, currentToolCalls []ToolCall, ch chan<- StreamResult) (bool, []ToolCall) {
+func (p *anthropicProvider) handleStreamEvent(event streamEvent, currentText *strings.Builder, currentToolCalls []ToolCall, ch chan<- StreamResult, logDir, model string, messages []Message, tools []ToolDefinition, thinkContent *string) (bool, []ToolCall) {
 	switch event.Type {
 	case "content_block_start":
 		// 开始新的内容块，检查是否是 tool_use 类型
@@ -344,6 +360,7 @@ func (p *anthropicProvider) handleStreamEvent(event streamEvent, currentText *st
 				ToolCalls: currentToolCalls,
 			}
 		} else if event.Delta.Type == "thinking_delta" {
+			*thinkContent += event.Delta.Thinking
 			ch <- StreamResult{
 				Think:     event.Delta.Thinking,
 				ToolCalls: currentToolCalls,
@@ -370,13 +387,24 @@ func (p *anthropicProvider) handleStreamEvent(event streamEvent, currentText *st
 		}
 		// 发送完成信号
 		ch <- StreamResult{
-			Done:         true,
 			ToolCalls:    currentToolCalls,
 			FinishReason: stopReason,
 			Usage:        event.Usage.toUsage(),
 		}
-		return true, currentToolCalls
-	case "message_stop":
+		// 写入交互日志
+		if logDir != "" {
+			go LogInteraction(logDir, "anthropic", &InteractionLog{
+				Model:      model,
+				Messages:   messages,
+				Tools:      tools,
+				Usage:      event.Usage.toUsage(),
+				Response:   currentText.String(),
+				ToolCalls:  currentToolCalls,
+				Think:      *thinkContent,
+				StopReason: string(stopReason),
+			})
+		}
+	case "message_stop": // 在 message_delta 后会跟一个message_stop，里面没有实际信息
 		ch <- StreamResult{
 			Done:      true,
 			ToolCalls: currentToolCalls,

--- a/pkg/services/llm/audit.go
+++ b/pkg/services/llm/audit.go
@@ -1,0 +1,64 @@
+package llm
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// InteractionLog LLM 交互日志
+type InteractionLog struct {
+	Timestamp  string           `json:"timestamp"`
+	Provider   string           `json:"provider"`
+	Model      string           `json:"model"`
+	Messages   []Message        `json:"messages"`
+	Tools      []ToolDefinition `json:"tools"`
+	Usage      *Usage           `json:"usage,omitempty"`
+	Think      string           `json:"think,omitempty"`
+	Response   string           `json:"response"`
+	ToolCalls  []ToolCall       `json:"tool_calls,omitempty"`
+	StopReason string           `json:"stop_reason,omitempty"`
+	Error      string           `json:"error,omitempty"`
+}
+
+var auditMu sync.Mutex
+
+// LogInteraction 写入交互日志
+func LogInteraction(logDir, provider string, log *InteractionLog) {
+	if logDir == "" {
+		return
+	}
+
+	log.Timestamp = time.Now().UTC().Format(time.RFC3339)
+	log.Provider = provider
+
+	filename := filepath.Join(logDir, provider+"_"+time.Now().Format("2006-01-02_15")+".jsonl")
+
+	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
+		logger().Warnw("create log dir failed", "path", filename, "err", err)
+		return
+	}
+
+	f, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		logger().Warnw("open log file failed", "path", filename, "err", err)
+		return
+	}
+
+	auditMu.Lock()
+	data, err := json.Marshal(log)
+	if err != nil {
+		auditMu.Unlock()
+		f.Close()
+		logger().Infow("marshal log failed", "err", err)
+		return
+	}
+
+	if _, err := f.Write(append(data, '\n')); err != nil {
+		logger().Infow("write log failed", "err", err)
+	}
+	auditMu.Unlock()
+	f.Close()
+}

--- a/pkg/services/llm/openai.go
+++ b/pkg/services/llm/openai.go
@@ -117,6 +117,23 @@ func (p *openAIProvider) Chat(ctx context.Context, cfg *config, messages []Messa
 		})
 	}
 
+	// 写入交互日志
+	if cfg.logDir != "" {
+		var thinkContent string
+		if resp.Choices[0].Message.ReasoningContent != "" {
+			thinkContent = resp.Choices[0].Message.ReasoningContent
+		}
+		go LogInteraction(cfg.logDir, "openai", &InteractionLog{
+			Model:     cfg.model,
+			Messages:  messages,
+			Tools:     tools,
+			Usage:     result.Usage,
+			Response:  result.Content,
+			ToolCalls: result.ToolCalls,
+			Think:     thinkContent,
+		})
+	}
+
 	return result, nil
 }
 
@@ -209,7 +226,7 @@ func (p *openAIProvider) StreamChat(ctx context.Context, cfg *config, messages [
 		defer resp.Body.Close()
 
 		// 解析流响应
-		if err := p.parseStreamResponse(resp.Body, ch, cfg.debug); err != nil {
+		if err := p.parseStreamResponse(resp.Body, ch, cfg.debug, cfg.logDir, cfg.model, messages, tools); err != nil {
 			ch <- StreamResult{Error: err}
 		}
 	}()
@@ -218,12 +235,14 @@ func (p *openAIProvider) StreamChat(ctx context.Context, cfg *config, messages [
 }
 
 // parseStreamResponse 解析流式响应
-func (p *openAIProvider) parseStreamResponse(body io.Reader, ch chan<- StreamResult, debug bool) error {
+func (p *openAIProvider) parseStreamResponse(body io.Reader, ch chan<- StreamResult, debug bool, logDir, model string, messages []Message, tools []ToolDefinition) error {
 	bufReader := bufio.NewReaderSize(body, 1024)
 
 	var currentToolCalls []ToolCall
 	var finishReason FinishReason
 	var lines int
+	var responseText string
+	var thinkContent string
 
 	for {
 		lines++
@@ -320,6 +339,12 @@ func (p *openAIProvider) parseStreamResponse(body io.Reader, ch chan<- StreamRes
 			result.Usage = chunk.Usage.toUsage()
 		}
 
+		// 累积响应内容
+		responseText += delta.Content
+		if delta.ReasoningContent != "" {
+			thinkContent += delta.ReasoningContent
+		}
+
 		// 检查是否需要结束流：
 		// 1. finish_reason 不为空（标准行为）
 		// 2. tool_calls_len 为 0 且之前累积了 tool_calls（DeepSeek 行为）
@@ -334,6 +359,19 @@ func (p *openAIProvider) parseStreamResponse(body io.Reader, ch chan<- StreamRes
 		if shouldEndStream {
 			logger().Infow("stream done", "finish_reason", finishReason,
 				"tool_calls_count", len(currentToolCalls), "lines", lines)
+			// 写入交互日志
+			if logDir != "" {
+				go LogInteraction(logDir, "openai", &InteractionLog{
+					Model:      model,
+					Messages:   messages,
+					Tools:      tools,
+					Usage:      result.Usage,
+					Response:   responseText,
+					ToolCalls:  currentToolCalls,
+					Think:      thinkContent,
+					StopReason: string(finishReason),
+				})
+			}
 			return nil
 		}
 	}

--- a/pkg/services/llm/options.go
+++ b/pkg/services/llm/options.go
@@ -17,6 +17,7 @@ type config struct {
 	httpClient  HTTPDoer
 	headers     map[string]string
 	debug       bool
+	logDir      string
 }
 
 // HTTPDoer HTTP 请求接口
@@ -117,6 +118,13 @@ func WithStream(stream bool) Option {
 func WithDebug(debug bool) Option {
 	return func(c *config) {
 		c.debug = debug
+	}
+}
+
+// WithLogDir 设置日志目录
+func WithLogDir(logDir string) Option {
+	return func(c *config) {
+		c.logDir = logDir
 	}
 }
 

--- a/pkg/services/stores/llm.go
+++ b/pkg/services/stores/llm.go
@@ -35,6 +35,7 @@ func init() {
 		llm.WithBaseURL(settings.Current.Embedding.URL),
 		llm.WithModel(settings.Current.Embedding.Model),
 		llm.WithDebug(settings.Current.Embedding.Debug),
+		llm.WithLogDir(settings.Current.Embedding.LogDir),
 	)
 	if err != nil {
 		logger().Fatalw("create llm embedding client failed", "err", err)
@@ -48,6 +49,7 @@ func init() {
 		llm.WithBaseURL(settings.Current.Interact.URL),
 		llm.WithModel(settings.Current.Interact.Model),
 		llm.WithDebug(settings.Current.Interact.Debug),
+		llm.WithLogDir(settings.Current.Interact.LogDir),
 	)
 	if err != nil {
 		logger().Fatalw("create llm interact client failed", "err", err)
@@ -61,6 +63,7 @@ func init() {
 		llm.WithBaseURL(settings.Current.Summarize.URL),
 		llm.WithModel(settings.Current.Summarize.Model),
 		llm.WithDebug(settings.Current.Summarize.Debug),
+		llm.WithLogDir(settings.Current.Summarize.LogDir),
 	)
 	if err != nil {
 		logger().Fatalw("create llm summarize client failed", "err", err)

--- a/pkg/settings/config.go
+++ b/pkg/settings/config.go
@@ -73,6 +73,7 @@ type Provider struct {
 	Model  string `envconfig:"MODEL" required:"true"`
 	Type   string `envconfig:"type" default:"openai" desc:"provider type: openai, anthropic, openrouter, ollama"`
 	Debug  bool   `envconfig:"debug" desc:"enable debug mode for this provider"`
+	LogDir string `envconfig:"log_dir" desc:"directory to log LLM interactions, files named by date (jsonl format)"`
 }
 
 func (c *Config) GetOAuthName() string {


### PR DESCRIPTION
Add LogDir config to each Provider (openai/anthropic) for writing LLM interaction logs as JSONL files named by date and provider.

- Add LogDir field to settings.Provider struct
- Add logDir to llm.config and WithLogDir option
- Add audit.go with InteractionLog struct and LogInteraction func using mutex-protected open-write-close pattern (no file handle cache)
- Wire logging into openai.go Chat and StreamChat (parseStreamResponse)
- Wire logging into anthropic.go Chat and StreamChat (message_delta)
- Pass WithLogDir to all three llm clients in stores/llm.go