### PR TITLE
feat(capability): add API capability vector search support

### DIFF
--- a/data/schemas/pg_11_match_capability.sql
+++ b/data/schemas/pg_11_match_capability.sql
@@ -1,0 +1,30 @@
+-- Capability vector stored procedure for semantic matching
+CREATE OR REPLACE FUNCTION vector_match_capability_4 (
+  query_embedding vector(1024),
+  similarity_threshold float,
+  match_count int
+)
+RETURNS TABLE (
+  doc_id bigint,
+  subject text,
+  similarity float
+)
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    acv.cap_id as doc_id,
+    acv.subject,
+    (acv.embedding <=> query_embedding) as similarity
+  FROM api_capability_vector acv
+  WHERE (acv.embedding <=> query_embedding) < similarity_threshold
+  ORDER BY acv.embedding <=> query_embedding
+  LIMIT match_count;
+END;
+$$ LANGUAGE plpgsql;
+
+-- IVFFlat index for vector search performance
+CREATE INDEX IF NOT EXISTS idx_capability_vector_embedding
+ON api_capability_vector
+USING ivfflat (embedding vector_cosine_ops)
+WITH (lists = 100);

--- a/docs/capability.yaml
+++ b/docs/capability.yaml
@@ -1,0 +1,131 @@
+depends:
+  comm: 'github.com/cupogo/andvari/models/comm'
+  oid: 'github.com/cupogo/andvari/models/oid'
+  corpus: 'github.com/liut/morign/pkg/models/corpus'
+
+dbcode: bun
+modelpkg: capability
+
+models:
+
+  - name: Capability
+    comment: 'API 能力描述'
+    tableTag: 'api_capability,alias:ac'
+    fields:
+      - type: comm.DefaultModel
+      - comment: operationId（可为空，公开接口无此字段）
+        name: OperationID
+        type: string
+        tags: {bson: 'operationID', json: 'operationID', pg: ',notnull,type:varchar(63)'}
+        isset: true
+        query: 'equal'
+      - comment: API 路径，如 /api/accounts/{id}
+        name: Endpoint
+        type: string
+        tags: {bson: 'endpoint', json: 'endpoint', pg: ',notnull,type:varchar(125)'}
+        isset: true
+        query: 'match'
+      - comment: HTTP 方法 GET/POST/PUT/DELETE 等
+        name: Method
+        type: string
+        tags: {bson: 'method', json: 'method', pg: ',notnull,type:varchar(10)'}
+        isset: true
+        query: 'equal'
+      - comment: 简短描述
+        name: Summary
+        type: string
+        tags: {bson: 'summary', json: 'summary', pg: ',notnull,type:text'}
+        isset: true
+      - comment: 详细描述
+        name: Description
+        type: string
+        tags: {bson: 'description', json: 'description', pg: ',notnull,type:text'}
+        isset: true
+      - comment: 参数结构 JSON
+        name: Parameters
+        type: '[]SwaggerParam'
+        tags: {bson: 'parameters', json: 'parameters,omitempty', pg: ",notnull,type:jsonb,default:'[]'"}
+        isset: true
+      - comment: 响应结构 JSON
+        name: Responses
+        type: string
+        tags: {bson: 'responses', json: 'responses,omitempty', pg: ",notnull,type:jsonb,default:'{}'"}
+        isset: true
+      - comment: API 标签
+        name: Tags
+        type: '[]string'
+        tags: {bson: 'tags', json: 'tags,omitempty', pg: ",notnull,type:jsonb,default:'[]'"}
+        isset: true
+      - type: comm.MetaField
+    oidcat: file
+    specNs: Cap
+    hooks:
+      afterCreated: yes
+      afterLoad: yes
+      afterList: yes
+
+  - name: CapabilityVector
+    comment: 'API 能力向量'
+    tableTag: 'api_capability_vector,alias:cv'
+    fields:
+      - type: comm.DefaultModel
+      - comment: 关联的 Capability ID
+        name: CapID
+        type: oid.OID
+        tags: {bson: 'capID', json: 'capID', pg: 'cap_id,notnull'}
+        isset: true
+        query: 'equal'
+      - comment: 主题 基于 summary + description 等生成
+        name: Subject
+        type: string
+        tags: {bson: 'subject', json: 'subject', pg: 'subject,notnull,type:text'}
+        isset: true
+      - comment: 语义向量 1024 维
+        name: Vector
+        type: corpus.Vector
+        tags: {bson: 'vector', json: 'vector', pg: 'embedding,notnull,type:vector(1024)'}
+        isset: true
+      - type: comm.MetaField
+    oidcat: event
+    specNs: Cap
+
+  - name: SwaggerParam
+    comment: swagger 参数定义
+    fields:
+      - comment: 参数类型
+        name: Type
+        type: string
+        tags: {json: 'type', yaml: 'type'}
+      - comment: 参数描述
+        name: Description
+        type: string
+        tags: {json: 'description', yaml: 'description'}
+      - comment: 参数名称
+        name: Name
+        type: string
+        tags: {json: 'name', yaml: 'name'}
+      - comment: 参数位置 header/query/body/path
+        name: In
+        type: string
+        tags: {json: 'in', yaml: 'in'}
+      - comment: 是否必填
+        name: Required
+        type: bool
+        tags: {json: 'required', yaml: 'required'}
+      - comment: 参数示例
+        name: Example
+        type: string
+        tags: {json: 'example,omitempty', yaml: 'example'}
+      - comment: schema 定义
+        name: Schema
+        type: any
+        tags: {json: 'schema,omitempty', yaml: 'schema'}
+
+stores:
+  - name: capabilityStore
+    iname: CapabilityStore
+    embed: CapabilityStoreX
+    siname: Capability
+    hods:
+      - { name: Capability, type: LGCUD }
+      - { name: CapabilityVector, type: LGC }

--- a/docs/plans/2026-04-17-001-feat-agent-api-capability-plan.md
+++ b/docs/plans/2026-04-17-001-feat-agent-api-capability-plan.md
@@ -1,0 +1,788 @@
+---
+title: "feat: Agent API Capability 向量检索"
+type: feat
+status: active
+date: 2026-04-17
+origin: docs/brainstorms/2026-04-10-agent-api-discovery-requirements.md
+---
+
+# Agent API Capability 向量检索
+
+## Overview
+
+实现 Agent 项目对各项目 swagger API 的本地同步与向量检索能力，使 LLM 能够根据用户自然语言意图动态匹配相关 API，无需加载完整 swagger 文档。
+
+## Problem Statement
+
+多个后端项目（项目 A 约 272 个 API，项目 C 约 450 个）通过 Bus 项目汇集。用户需要 Agent 根据自然语言意图（如"查订单"）动态发现和调用相关 API，而非一次性加载全部 API 元信息导致 context 膨胀。
+
+## Key Decisions (from origin)
+
+- **不动 Bus**: 所有权限检查由 Bus middleware 执行，Agent 不做预检 (R4)
+- **本地向量检索**: 复用现有 embedding 基础设施，按需匹配 (R2)
+- **事后权限处理**: 403 时告知用户，而非事前查询 (R4)
+- **直接使用 operationId**: operationId 一旦确定稳定不变 (R2)
+
+## Proposed Solution
+
+### Phase 1: 数据模型与存储
+
+**1.1 创建 model 文件**
+
+使用 codegen 生成：
+
+```bash
+make codegen MDs=docs/capability.yaml
+```
+
+这会在 `pkg/models/capability/` 和 `pkg/services/stores/` 下生成对应的 `*_gen.go` 文件。
+
+在生成的文件基础上进行扩展：
+
+```
+pkg/models/capability/
+  capability_gen.go    # 自动生成的结构
+  capability_x.go      # 扩展方法
+
+pkg/services/stores/
+  capability_gen.go    # 自动生成的 Store 接口和基础 CRUD
+  capability_x.go      # 扩展方法
+```
+
+**api_capability 表结构**（见 origin Data Model）:
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| id | bigint | oid.OID (PK) |
+| operation_id | varchar | operationId（可为空，公开接口） |
+| endpoint | varchar | API 路径，如 `/api/accounts/{id}` |
+| method | varchar | GET/POST/PUT/DELETE 等 |
+| summary | text | 简短描述 |
+| description | text | 详细描述 |
+| parameters | jsonb | 参数结构 |
+| responses | jsonb | 响应结构 |
+
+**唯一约束**: `method + endpoint`
+
+**api_capability_vector 表**:
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| id | bigint | oid.OID (PK) |
+| cap_id | bigint | FK to api_capability |
+| subject | text | 基于 summary + description 生成 |
+| embedding | vector(1024) | 语义向量 |
+
+**1.2 表结构**
+
+表结构通过 codegen 自动生成（bun.AutoMigrate），无需手动迁移文件。
+
+**api_capability 表**：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| id | bigint | oid.OID (PK) |
+| operation_id | varchar | operationId（可为空，公开接口） |
+| endpoint | varchar | API 路径，如 `/api/accounts/{id}` |
+| method | varchar | GET/POST/PUT/DELETE 等 |
+| summary | text | 简短描述 |
+| description | text | 详细描述 |
+| parameters | jsonb | 参数结构 |
+| responses | jsonb | 响应结构 |
+
+**唯一约束**: `method + endpoint`
+
+**api_capability_vector 表**：
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| id | bigint | oid.OID (PK) |
+| cap_id | bigint | FK to api_capability |
+| subject | text | 基于 summary + description 生成 |
+| embedding | vector(1024) | 语义向量 |
+
+**需创建 stored procedure**:
+
+```sql
+CREATE OR REPLACE FUNCTION vector_match_capability_4(query_embedding vector(1024), threshold float4, limit_n int)
+RETURNS TABLE(id bigint, cap_id bigint, subject text, similarity float4) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT acv.id, acv.cap_id, acv.subject,
+           (acv.embedding <=> query_embedding) AS similarity
+    FROM api_capability_vector acv
+    WHERE (acv.embedding <=> query_embedding) < threshold
+    ORDER BY acv.embedding <=> query_embedding
+    LIMIT limit_n;
+END;
+$$ LANGUAGE plpgsql;
+```
+
+### Phase 2: Store 层实现
+
+**2.1 创建 capability store**
+
+使用 codegen 生成后，在生成的文件基础上扩展：
+
+```
+pkg/services/stores/
+  capability_gen.go    # 自动生成的 Store 接口和基础 CRUD
+  capability_x.go      # 导入/导出/向量操作
+```
+
+**codegen 配置** `docs/capability.yaml` 中 store 部分：
+
+```yaml
+stores:
+  - name: capabilityStore
+    iname: CapabilityStore
+    siname: Capability
+    hods:
+      - { name: Capability, type: LGCUD }
+      - { name: CapabilityVector, type: LGC }
+```
+
+**Store 接口设计**:
+
+```go
+type CapabilityStore interface {
+    CapabilityStoreX
+
+    ListCapability(ctx context.Context, spec *CapabilitySpec) (data Capabilities, total int, err error)
+    GetCapability(ctx context.Context, id string) (obj *Capability, err error)
+    CreateCapability(ctx context.Context, in CapabilityBasic) (obj *Capability, err error)
+    UpdateCapability(ctx context.Context, id string, in CapabilitySet) error
+    DeleteCapability(ctx context.Context, id string) error
+
+    GetCapabilityVector(ctx context.Context, id string) (obj *CapabilityVector, err error)
+    CreateCapabilityVector(ctx context.Context, in CapabilityVectorBasic) (obj *CapabilityVector, err error)
+}
+
+type CapabilityStoreX interface {
+    ImportCapabilities(ctx context.Context, r io.Reader, lw io.Writer) error
+    ExportCapabilities(ctx context.Context, ea ExportArg) error
+    SyncEmbeddingCapabilities(ctx context.Context, spec *CapabilitySpec) error
+    MatchCapabilities(ctx context.Context, ms MatchSpec) (data CapabilityMatches, err error)
+}
+```
+
+**2.2 MatchSpec 扩展**
+
+复用现有的 `stores.MatchSpec`（在 corpus_x.go 中定义），因为语义匹配逻辑相同。
+
+**2.3 向量生成时机**
+
+- 导入时：同步生成向量（`ImportCapabilities` 内调用 `SyncEmbeddingCapabilities`）
+- 增量更新：按需调用 `SyncEmbeddingCapabilities`
+
+### Phase 3: CLI 命令
+
+新增命令：
+
+```bash
+# 导入 swagger（支持 yaml/json 解析）
+./morrigan import-swagger <file_or_dir> [--diff <logfile>]
+
+# 同步向量
+./morrigan embedding --target capability [--limit 100]
+```
+
+**3.1 Swagger 解析**
+
+输入：swagger.yaml 或 swagger.json 文件
+输出：Capability 列表
+
+**Swagger 文档结构**（参考 `scaffold/scripts/sqlgen/swag.go`）:
+
+```go
+type swagDoc struct {
+    Swagger string `json:"swagger" yaml:"swagger"`
+    Info    struct { Title string }
+    Paths   paths `json:"paths" yaml:"paths"`
+}
+
+type apiEntry struct {
+    OperationID string         `json:"operationId" yaml:"operationId"`
+    Summary     string         `json:"summary" yaml:"summary"`
+    Description string         `json:"description" yaml:"description"`
+    Parameters  []any          `json:"parameters" yaml:"parameters"`
+    Responses   map[string]any `json:"responses" yaml:"responses"`
+    Tags        []string       `json:"tags" yaml:"tags"`
+}
+
+func loadDoc(docfile string) (*swagDoc, error) {
+    yf, err := os.Open(docfile)
+    if err != nil {
+        return nil, err
+    }
+    doc := new(swagDoc)
+    err = yaml.NewDecoder(yf).Decode(doc)
+    if err != nil {
+        return nil, err
+    }
+
+    return doc, nil
+}
+
+```
+
+解析字段映射：
+
+| swagger 字段 | capability 字段 |
+|-------------|-----------------|
+| paths.{path}.{method}.operationId | OperationID |
+| paths.{path}.{method} | Method + Endpoint |
+| paths.{path}.{method}.summary | Summary |
+| paths.{path}.{method}.description | Description |
+| paths.{path}.{method}.parameters | Parameters (JSON) |
+| paths.{path}.{method}.responses | Responses (JSON) |
+
+**冲突处理**: 基于 `method + endpoint` 唯一约束，重复时覆盖。
+
+### Phase 4: Store 注册
+
+**4.1 Wrap 结构扩展**
+
+**不需要手动修订，用 codegen 会自动修订**
+
+```go
+// wrap.go
+type Wrap struct {
+    db *pgx.DB
+    corpuStore *corpuStore
+    capabilityStore *capabilityStore  // 新增
+    // ...
+}
+
+// wrap.go NewWithDB
+w.capabilityStore = &capabilityStore{w: w}
+
+// stores.go Sgt()
+func (s *stores) Capability() CapabilityStore { return s.w.capabilityStore }
+```
+
+### Phase 5: Bus 集成
+
+**5.1 HTTP 客户端**
+
+```go
+// pkg/services/stores/capability_invoker.go
+type CapabilityInvoker struct {
+    httpClient *http.Client
+    baseURL    string // settings.Current.OAuthPrefix
+}
+
+func (inv *CapabilityInvoker) Invoke(ctx context.Context, cap *Capability, params map[string]any) (*http.Response, error) {
+    // 构造 URL: baseURL + endpoint
+    url := inv.baseURL + cap.Endpoint
+
+    // 根据 method 构造请求
+    var body io.Reader
+    if cap.Method == "POST" || cap.Method == "PUT" || cap.Method == "PATCH" {
+        body = buildBody(params)
+    }
+
+    req, err := http.NewRequestWithContext(ctx, cap.Method, url, body)
+    if err != nil {
+        return nil, err
+    }
+
+    // 设置 Header（Content-Type, Authorization 等）
+    req.Header.Set("Content-Type", "application/json")
+
+    return inv.httpClient.Do(req)
+}
+```
+
+**5.2 403 处理**
+
+```go
+resp, err := inv.Invoke(ctx, cap, params)
+if err != nil {
+    return nil, err
+}
+defer resp.Body.Close()
+
+if resp.StatusCode == 403 {
+    return nil, ErrPermissionDenied
+}
+```
+
+**5.3 MCP Tool 注册**
+
+参考 `pkg/services/tools/registry.go` 的模式：
+
+```go
+// pkg/services/tools/defines.go - 定义工具描述
+const (
+    ToolNameCapabilityMatch = "capability_match" // API 能力匹配
+)
+
+var capabilityMatchDescriptor = mcps.ToolDescriptor{
+    Name:        ToolNameCapabilityMatch,
+    Description: "Match API capabilities by user intent. Returns 3-5 relevant APIs based on semantic similarity.",
+    InputSchema: map[string]any{
+        "type": "object",
+        "properties": map[string]any{
+            "intent": map[string]any{
+                "type":        "string",
+                "description": "User's natural language intent (e.g., '查订单', '创建文章')",
+            },
+            "limit": map[string]any{
+                "type":        "integer",
+                "description": "Max results to return (default: 5)",
+                "default":     5,
+            },
+        },
+        "required": []string{"intent"},
+    },
+}
+```
+
+**Capability Store Invoker**（在 `capability_x.go` 中实现）:
+
+```go
+// pkg/services/stores/capability_x.go
+func (s *capabilityStore) InvokerForMatch() mcps.Invoker {
+    return func(ctx context.Context, args map[string]any) (map[string]any, error) {
+        intent := mcps.StringArg(args, "intent")
+        if intent == "" {
+            return mcps.BuildToolErrorResult("missing required argument: intent"), nil
+        }
+
+        limit, _, _ := mcps.IntArg(args, "limit")
+        if limit == 0 {
+            limit = 5
+        }
+
+        caps, err := s.MatchCapabilities(ctx, stores.MatchSpec{
+            Query: intent,
+            Limit: limit,
+        })
+        if err != nil {
+            return mcps.BuildToolErrorResult(err.Error()), nil
+        }
+        if len(caps) == 0 {
+            return mcps.BuildToolSuccessResult("No matching APIs found"), nil
+        }
+
+        // 返回匹配结果
+        result := make([]map[string]any, 0, len(caps))
+        for _, cap := range caps {
+            result = append(result, map[string]any{
+                "id":          cap.StringID(),
+                "operation_id": cap.OperationID,
+                "endpoint":    cap.Endpoint,
+                "method":      cap.Method,
+                "summary":     cap.Summary,
+                "subject":     cap.Subject,
+            })
+        }
+        return mcps.BuildToolSuccessResult(result), nil
+    }
+}
+```
+
+**注册到 Registry**（在 `initTools` 中）:
+
+```go
+// pkg/services/tools/registry.go - initTools()
+r.tools = append(r.tools, capabilityMatchDescriptor)
+r.invokers[ToolNameCapabilityMatch] = sto.Capability().InvokerForMatch()
+```
+
+**capability_invoke Tool**（调用具体 API）:
+
+```go
+// pkg/services/tools/defines.go
+const (
+    ToolNameCapabilityInvoke = "capability_invoke" // API 能力调用
+)
+
+var capabilityInvokeDescriptor = mcps.ToolDescriptor{
+    Name:        ToolNameCapabilityInvoke,
+    Description: "Invoke a specific API capability by ID. Returns the API response from Bus.",
+    InputSchema: map[string]any{
+        "type": "object",
+        "properties": map[string]any{
+            "id": map[string]any{
+                "type":        "string",
+                "description": "Capability ID from capability_match result",
+            },
+            "params": map[string]any{
+                "type":        "object",
+                "description": "API parameters (path variables, query params, body, etc.)",
+            },
+        },
+        "required": []string{"id"},
+    },
+}
+```
+
+**CapabilityStore InvokerForInvoke**（在 `capability_x.go` 中实现）:
+
+```go
+// pkg/services/stores/capability_x.go
+func (s *capabilityStore) InvokerForInvoke(invoker *CapabilityInvoker) mcps.Invoker {
+    return func(ctx context.Context, args map[string]any) (map[string]any, error) {
+        id := mcps.StringArg(args, "id")
+        if id == "" {
+            return mcps.BuildToolErrorResult("missing required argument: id"), nil
+        }
+
+        cap, err := s.GetCapability(ctx, id)
+        if err != nil {
+            return mcps.BuildToolErrorResult(err.Error()), nil
+        }
+
+        params, _ := args["params"].(map[string]any)
+        if params == nil {
+            params = make(map[string]any)
+        }
+
+        resp, err := invoker.Invoke(ctx, cap, params)
+        if err != nil {
+            return mcps.BuildToolErrorResult(err.Error()), nil
+        }
+        defer resp.Body.Close()
+
+        if resp.StatusCode == 403 {
+            return mcps.BuildToolErrorResult("Permission denied: no access to this API"), nil
+        }
+
+        body, _ := io.ReadAll(resp.Body)
+        return mcps.BuildToolSuccessResult(string(body)), nil
+    }
+}
+```
+
+**注册到 Registry**（在 `initTools` 中）:
+
+```go
+// pkg/services/tools/registry.go - initTools()
+r.tools = append(r.tools, capabilityInvokeDescriptor)
+r.invokers[ToolNameCapabilityInvoke] = sto.Capability().InvokerForInvoke(capabilityInvoker)
+```
+
+## Technical Considerations
+
+### Bus API 调用
+
+调用 Bus 的目标 URL 格式：
+```
+settings.Current.OAuthPrefix + endpoint
+```
+
+HTTP Method 使用 capability 表中的 method 字段。
+
+### 向量检索 (Stored Procedure)
+
+使用 stored procedure 而非 inline raw SQL，减少参数传递次数：
+
+```go
+func (s *capabilityStore) matchVectorWith(ctx context.Context, vec corpus.Vector, threshold float32, limit int) (data CapabilityMatches, err error) {
+    if len(vec) != corpus.VectorLen {
+        return
+    }
+    err = s.w.db.NewRaw("SELECT * FROM vector_match_capability_4(?, ?, ?)", vec, threshold, limit).
+        Scan(ctx, &data)
+    return
+}
+```
+
+**需创建 stored procedure**:
+
+```sql
+CREATE OR REPLACE FUNCTION vector_match_capability_4(query_embedding vector(1024), threshold float4, limit_n int)
+RETURNS TABLE(id bigint, cap_id bigint, subject text, similarity float4) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT acv.id, acv.cap_id, acv.subject,
+           (acv.embedding <=> query_embedding) AS similarity
+    FROM api_capability_vector acv
+    WHERE (acv.embedding <=> query_embedding) < threshold
+    ORDER BY acv.embedding <=> query_embedding
+    LIMIT limit_n;
+END;
+$$ LANGUAGE plpgsql;
+```
+
+### Subject 生成 (增强版)
+
+
+```go
+// models/capable/capab_x.go
+func (c *Capability) GetSubject() string {
+    // 基础: summary + description
+    subject := c.Summary
+    if c.Description != "" {
+        subject += " " + c.Description
+    }
+    // 增强: 从 parameters 和 responses 提取关键词（未来扩展）
+    // 可通过自定义方法实现，未来可能添加新字段
+    return subject
+}
+```
+
+未来可扩展：parameters/responses 结构解析后提取关键字段加入 subject。
+
+### Swagger 解析库
+
+考虑使用现成的 swagger 解析库，如 `github.com/getkin/kin-openapi` 或 `github.com/go-openapi/spec`。
+
+### 导入格式
+
+支持直接解析 swagger.yaml/json （复用 ImportDocs 逻辑）。
+
+## System-Wide Impact
+
+### Interaction Graph
+
+1. `import-swagger` → 解析 swagger → `UpsertCapability` → `CreateCapabilityVector` → `GetEmbedding`
+2. `embedding --target capability` → `SyncEmbeddingCapabilities` → `GetEmbedding` → 更新 `CapabilityVector`
+3. 用户请求 → `MatchCapabilities` → SQL 向量匹配 → 返回候选 Capabilities
+4. LLM 选择 → `CapabilityInvoker.Invoke` → `OAuthPrefix + endpoint` → Bus → 403/200
+
+### Error & Failure Propagation
+
+- `GetEmbedding` 失败：跳过该条 capability 的向量生成，记录日志
+- `CreateCapability` 唯一约束冲突：覆盖已有记录（Upsert 逻辑）
+- 向量匹配失败：返回空列表，Agent 降级为关键词匹配
+
+### Integration Test Scenarios
+
+1. 导入包含 500+ API 的 swagger 文件，验证向量生成完整
+2. 导入重复 swagger（部分更新），验证覆盖逻辑正确
+3. `MatchCapabilities` 查询"查订单"，返回相关 API（不包含无关 API）
+4. operation_id 为空的公开 API 也能正常导入和匹配
+
+## Acceptance Criteria
+
+- [ ] `make codegen MDs=docs/capability.yaml` 生成 model 和 store 骨架代码
+- [ ] 在生成的 `capability_gen.go` 基础上扩展 `capability_x.go` 实现 `CapabilityStoreX` 接口
+- [ ] `import-swagger` 命令能解析 swagger.yaml/json 并导入 capability
+- [ ] `embedding --target capability` 能批量生成/更新向量
+- [ ] `capability_match` Tool 能返回 3-5 个相关 API
+- [ ] `capability_invoke` Tool 能正确调用 Bus API
+- [ ] 403 响应能正确转换为用户可理解错误信息
+- [ ] operation_id 为空的公开 API 能正常导入
+- [ ] 重复导入（相同 method+endpoint）能正确覆盖
+
+## Success Metrics
+
+- 导入 700+ API 的 swagger，耗时 < 30 秒
+- 向量生成 700+ 条，耗时 < 2 分钟
+- 向量匹配延迟 < 100ms
+
+## Dependencies & Risks
+
+**依赖**:
+- PostgreSQL pgvector 扩展
+- 现有 `GetEmbedding` 函数
+- `settings.Current.OAuthPrefix` 配置
+
+**风险**:
+- swagger 解析兼容性（不同项目的 swagger 实现可能有差异）
+- 向量匹配 threshold 需要试点调整
+
+## Deferred to Implementation
+
+- [Technical] `embedding --target capability` CLI 参数扩展（在现有 `embedding` 命令中添加 capability 支持）
+- [Technical] 公开 API（operation_id 为空）的 Bus 调用处理
+- [Technical] 降级策略（零匹配时的 fallback）
+
+## Enhancement Summary
+
+**Deepened on:** 2026-04-17
+**Sections enhanced:** 7
+**Research agents used:** security-sentinel, performance-oracle, kieran-rails-reviewer, Go patterns researcher
+
+### Key Improvements Discovered
+
+1. **Bug Fix**: `resp.Body.Close()` 在 Invoke 返回 error 时会 panic，需先检查 resp 不为 nil
+2. **Input Validation**: `buildBody(params)` 缺少对 capability.parameters schema 的验证
+3. **Performance**: Raw SQL 传 vec 参数 4 次，应改用 stored procedure 模式
+4. **Codegen**: 使用 `make codegen MDs=docs/mcps.yaml` 生成 model 和 store 骨架代码
+
+## Codegen 参考
+
+Model 和 Store 代码使用现有 codegen 机制生成：
+
+```bash
+make codegen MDs=docs/capability.yaml
+```
+
+配置参考 `docs/capability.yaml`：
+- 生成 `pkg/models/capability/capability_gen.go`
+- 生成 `pkg/services/stores/capability_gen.go`
+- 在生成的 `*_gen.go` 基础上扩展 `*_x.go`
+
+**注意**：Vector 字段类型使用 `bytes`（对应 `vector(1024)`），具体类型映射参考现有 corpus 模型。
+
+## Input Validation for Params
+
+**Severity: HIGH**
+
+`params map[string]any` 缺少 schema 验证：
+
+```go
+func validateParams(params map[string]any, paramSchema jsonb) error {
+    // TODO: 实现参数验证逻辑
+    // 验证类型、必填、格式等
+    return nil
+}
+
+func buildBody(params map[string]any) (io.Reader, error) {
+    data, err := json.Marshal(params)
+    if err != nil {
+        return nil, err
+    }
+    return bytes.NewReader(data), nil
+}
+```
+
+## Authorization Header 处理
+
+**Needs Clarification**
+
+Plan 未说明如何将 OAuth token 注入到 Bus 请求中。需确认：
+- Token 来源：settings 或 session？
+- 注入方式：Bearer token 或 Cookie？
+
+## Performance Considerations
+
+### 1. 向量检索：Raw SQL vs Stored Procedure
+
+**问题**: Raw SQL 传 vec 参数 4 次（~16KB 数据），应改用 stored procedure 模式。
+
+```go
+// 当前方案（传 4 次 vec）
+err = s.w.db.NewRaw(`
+    SELECT ... (acv.embedding <=> ?) ...
+`, vec, vec, threshold, vec, limit)
+
+// 推荐方案（传 1 次 vec）
+err = s.w.db.NewRaw("SELECT * FROM vector_match_capability_4(?, ?, ?)", vec, threshold, limit).
+    Scan(ctx, &data)
+```
+
+需创建 `vector_match_capability_4()` stored procedure：
+
+```sql
+CREATE OR REPLACE FUNCTION vector_match_capability_4(query_embedding vector(1024), threshold float4, limit_n int)
+RETURNS TABLE(id bigint, cap_id bigint, subject text, similarity float4) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT acv.id, acv.cap_id, acv.subject,
+           (acv.embedding <=> query_embedding) AS similarity
+    FROM api_capability_vector acv
+    WHERE (acv.embedding <=> query_embedding) < threshold
+    ORDER BY acv.embedding <=> query_embedding
+    LIMIT limit_n;
+END;
+$$ LANGUAGE plpgsql;
+```
+
+### 2. 批量导入优化
+
+700+ API 在 30 秒内导入需要：
+
+```go
+// 批量 upsert（使用多行 INSERT ... ON CONFLICT）
+const batchSize = 100
+for i := 0; i < len(capabilities); i += batchSize {
+    end := min(i+batchSize, len(capabilities))
+    batch := capabilities[i:end]
+    err = s.bulkUpsertCapabilities(ctx, batch)
+}
+```
+
+### 3. 数据库索引
+
+迁移文件中需添加 IVFFlat 索引：
+
+```sql
+-- 20260417-001-api_capability.up.sql
+CREATE INDEX ON api_capability_vector
+USING ivfflat (embedding vector_cosine_ops)
+WITH (lists = 100);
+```
+
+## Bug Fixes Required
+
+### 1. resp.Body.Close() Panic Bug
+
+```go
+// 错误：Invoke 返回 error 时 resp 为 nil，defer 会 panic
+resp, err := inv.Invoke(ctx, cap, params)
+if err != nil {
+    return nil, err
+}
+defer resp.Body.Close()  // BUG: 如果 resp 是 nil 则 panic
+
+// 正确：先检查 resp 不为 nil
+resp, err := inv.Invoke(ctx, cap, params)
+if err != nil {
+    return nil, err
+}
+if resp != nil {
+    defer resp.Body.Close()
+}
+```
+
+### 2. GetEmbedding 错误处理
+
+Plan 说明 "跳过该条" 但代码实现在 `SyncEmbeddingDocments` 中是立即返回错误：
+
+```go
+// 当前行为（失败整个 batch）
+vec, err := GetEmbedding(ctx, subject)
+if err != nil {
+    return err  // 失败整个流程
+}
+
+// Capability 应该的行为（跳过并继续）
+vec, err := GetEmbedding(ctx, subject)
+if err != nil {
+    logger().Warnw("skip capability due to embedding fail", "id", cap.ID, "err", err)
+    continue  // 跳过这条，继续处理下一条
+}
+```
+
+### 3. Embedding API 批处理 Bug
+
+**潜在问题**: `openai.go` 的 `Embedding()` 可能只返回第一个结果，批处理失效。实现时需验证：
+
+```go
+// 验证 Embedding 返回所有结果
+embeddings, err := llmEm.Embedding(ctx, texts)  // texts 是 []string
+if len(embeddings) != len(texts) {
+    return nil, fmt.Errorf("embedding count mismatch: got %d, want %d", len(embeddings), len(texts))
+}
+```
+
+## Technical Decisions
+
+### 1. 向量匹配 Stored Procedure 命名
+
+使用 `vector_match_capability_4()` 而非内联 SQL，以：
+- 减少参数传递（1 次 vec vs 4 次）
+- 与现有 `vector_match_docs_4()` 保持一致
+
+### 2. 错误处理策略
+
+- **导入阶段**: 单条失败跳过并记录，不中断整个流程
+- **匹配阶段**: 零匹配返回空列表，Agent 降级为关键词匹配
+- **调用阶段**: 403 转换为用户可理解错误
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-04-10-agent-api-discovery-requirements.md](docs/brainstorms/2026-04-10-agent-api-discovery-requirements.md)
+  - Key decisions: 本地向量检索、复用 GetEmbedding、不动 Bus、事后权限处理
+- **Codegen config:** `docs/capability.yaml` - 使用 `make codegen MDs=docs/capability.yaml` 生成代码
+- Corpus model pattern: `pkg/models/corpus/corpus_gen.go:19-50`
+- Store pattern: `pkg/services/stores/corpus_x.go:74-83`
+- CLI pattern: `main.go:36-62`
+- Vector matching pattern: `pkg/services/stores/corpus_x.go:258-280`
+- OpenAPI parsing: `github.com/getkin/kin-openapi`
+- pgvector docs: PostgreSQL pgvector extension`

--- a/main.go
+++ b/main.go
@@ -61,6 +61,40 @@ func importDocs(cc *cli.Context) error {
 	return nil
 }
 
+func importSwagger(cc *cli.Context) error {
+	input := cc.Args().First()
+	if input == "" {
+		return fmt.Errorf("input file or directory is required")
+	}
+
+	file, err := os.Open(input)
+	if err != nil {
+		logger().Warnw("open fail", "input", input, "err", err)
+		return err
+	}
+	defer file.Close()
+
+	difflog := cc.String("diff")
+	var lw *os.File
+	if len(difflog) > 0 {
+		lw, err = os.Create(difflog)
+		if err != nil {
+			logger().Warnw("create fail", "difflog", difflog, "err", err)
+			return err
+		}
+		defer lw.Close()
+	} else {
+		lw = os.Stderr
+	}
+
+	err = stores.Sgt().Capability().ImportCapabilities(cc.Context, file, lw)
+	if err != nil {
+		logger().Warnw("import swagger fail", "input", input, "err", err)
+		return err
+	}
+	return nil
+}
+
 func exportDocs(cc *cli.Context) error {
 	output := cc.Args().First() // csv
 	file, err := os.OpenFile(output, os.O_RDWR|os.O_CREATE, 0644)
@@ -96,8 +130,13 @@ func embeddingDocVector(cc *cli.Context) error {
 		spec.Limit = cc.Int("limit")
 		spec.Sort = "id"
 		return stores.Sgt().Convo().SyncEmbeddingMemories(ctx, spec)
+	case "capability":
+		spec := &stores.CapCapabilitySpec{}
+		spec.Limit = cc.Int("limit")
+		spec.Sort = "id"
+		return stores.Sgt().Capability().SyncEmbeddingCapabilities(ctx, spec)
 	default:
-		return fmt.Errorf("unsupported target: %s (supported: doc, mem)", target)
+		return fmt.Errorf("unsupported target: %s (supported: doc, mem, capability)", target)
 	}
 }
 
@@ -195,6 +234,15 @@ func main() {
 				},
 			},
 			{
+				Name:    "import-swagger",
+				Usage:   "import API capabilities from swagger yaml/json",
+				Aliases: []string{"import-capability"},
+				Action:  importSwagger,
+				Flags: []cli.Flag{
+					&cli.StringFlag{Name: "diff", Aliases: []string{"diff-log"}, Value: "", Usage: "a filename of diff"},
+				},
+			},
+			{
 				Name:    "export",
 				Usage:   "export documents to a csv",
 				Aliases: []string{"exportDocs"},
@@ -209,7 +257,7 @@ func main() {
 				Aliases: []string{"embedding-doc-vec"},
 				Action:  embeddingDocVector,
 				Flags: []cli.Flag{
-					&cli.StringFlag{Name: "target", Aliases: []string{"t"}, Value: "doc", Usage: "target to embed: doc|mem"},
+					&cli.StringFlag{Name: "target", Aliases: []string{"t"}, Value: "doc", Usage: "target to embed: doc|mem|capability"},
 					&cli.IntFlag{Name: "limit", Aliases: []string{"l"}, Value: 90, Usage: "limit for query"},
 				},
 			},

--- a/pkg/models/aigc/match.go
+++ b/pkg/models/aigc/match.go
@@ -1,0 +1,28 @@
+package aigc
+
+import (
+	"github.com/cupogo/andvari/models/oid"
+)
+
+// MatchResult 通用匹配结果结构
+// 用于向量检索返回的匹配结果
+type MatchResult struct {
+	// DocID 关联文档的 ID
+	DocID oid.OID `bson:"docID" extensions:"x-order=A" json:"docID" swaggertype:"string"`
+	// 主题
+	Subject string `bson:"subject" extensions:"x-order=B" form:"subject" json:"subject"`
+	// 相似度
+	Similarity float32 `bson:"similarity" extensions:"x-order=C" json:"similarity"`
+}
+
+// MatchResults is a slice of MatchResult
+type MatchResults []MatchResult
+
+// DocIDs returns the document IDs from all match results
+func (z MatchResults) DocIDs() (out oid.OIDs) {
+	out = make(oid.OIDs, 0, len(z))
+	for _, m := range z {
+		out = append(out, m.DocID)
+	}
+	return
+}

--- a/pkg/models/capability/capability_gen.go
+++ b/pkg/models/capability/capability_gen.go
@@ -1,0 +1,263 @@
+// This file is generated - Do Not Edit.
+
+package capability
+
+import (
+	comm "github.com/cupogo/andvari/models/comm"
+	oid "github.com/cupogo/andvari/models/oid"
+	corpus "github.com/liut/morign/pkg/models/corpus"
+)
+
+// consts of Capability API
+const (
+	CapabilityTable = "api_capability"
+	CapabilityAlias = "ac"
+	CapabilityLabel = "capability"
+	CapabilityTypID = "capability"
+)
+
+// Capability API 能力描述
+type Capability struct {
+	comm.BaseModel `bun:"table:api_capability,alias:ac" json:"-"`
+
+	comm.DefaultModel
+
+	CapabilityBasic
+
+	comm.MetaField
+} // @name capability
+
+type CapabilityBasic struct {
+	// operationId（可为空，公开接口无此字段）
+	OperationID string `bson:"operationID" bun:",notnull,type:varchar(63)" extensions:"x-order=A" form:"operationID" json:"operationID" pg:",notnull,type:varchar(63)"`
+	// API 路径，如 /api/accounts/{id}
+	Endpoint string `bson:"endpoint" bun:",notnull,type:varchar(125)" extensions:"x-order=B" form:"endpoint" json:"endpoint" pg:",notnull,type:varchar(125)"`
+	// HTTP 方法 GET/POST/PUT/DELETE 等
+	Method string `bson:"method" bun:",notnull,type:varchar(10)" extensions:"x-order=C" form:"method" json:"method" pg:",notnull,type:varchar(10)"`
+	// 简短描述
+	Summary string `bson:"summary" bun:",notnull,type:text" extensions:"x-order=D" form:"summary" json:"summary" pg:",notnull,type:text"`
+	// 详细描述
+	Description string `bson:"description" bun:",notnull,type:text" extensions:"x-order=E" form:"description" json:"description" pg:",notnull,type:text"`
+	// 参数结构 JSON
+	Parameters []SwaggerParam `bson:"parameters" bun:",notnull,type:jsonb,default:'[]'" extensions:"x-order=F" json:"parameters,omitempty" pg:",notnull,type:jsonb,default:'[]'"`
+	// 响应结构 JSON
+	Responses string `bson:"responses" bun:",notnull,type:jsonb,default:'{}'" extensions:"x-order=G" form:"responses" json:"responses,omitempty" pg:",notnull,type:jsonb,default:'{}'"`
+	// API 标签
+	Tags []string `bson:"tags" bun:",notnull,type:jsonb,default:'[]'" extensions:"x-order=H" json:"tags,omitempty" pg:",notnull,type:jsonb,default:'[]'"`
+	// for meta update
+	MetaDiff *comm.MetaDiff `bson:"-" bun:"-" json:"metaUp,omitempty" pg:"-" swaggerignore:"true"`
+} // @name capabilityBasic
+
+type Capabilities []Capability
+
+// Creating function call to it's inner fields defined hooks
+func (z *Capability) Creating() error {
+	if z.IsZeroID() {
+		z.SetID(oid.NewID(oid.OtFile))
+	}
+
+	return z.DefaultModel.Creating()
+}
+func NewCapabilityWithBasic(in CapabilityBasic) *Capability {
+	obj := &Capability{
+		CapabilityBasic: in,
+	}
+	_ = obj.MetaUp(in.MetaDiff)
+	return obj
+}
+func NewCapabilityWithID(id any) *Capability {
+	obj := new(Capability)
+	_ = obj.SetID(id)
+	return obj
+}
+func (_ *Capability) IdentityLabel() string { return CapabilityLabel }
+func (_ *Capability) IdentityModel() string { return CapabilityTypID }
+func (_ *Capability) IdentityTable() string { return CapabilityTable }
+func (_ *Capability) IdentityAlias() string { return CapabilityAlias }
+
+type CapabilitySet struct {
+	// operationId（可为空，公开接口无此字段）
+	OperationID *string `extensions:"x-order=A" json:"operationID"`
+	// API 路径，如 /api/accounts/{id}
+	Endpoint *string `extensions:"x-order=B" json:"endpoint"`
+	// HTTP 方法 GET/POST/PUT/DELETE 等
+	Method *string `extensions:"x-order=C" json:"method"`
+	// 简短描述
+	Summary *string `extensions:"x-order=D" json:"summary"`
+	// 详细描述
+	Description *string `extensions:"x-order=E" json:"description"`
+	// 参数结构 JSON
+	Parameters *[]SwaggerParam `extensions:"x-order=F" json:"parameters,omitempty"`
+	// 响应结构 JSON
+	Responses *string `extensions:"x-order=G" form:"responses" json:"responses,omitempty"`
+	// API 标签
+	Tags *[]string `extensions:"x-order=H" json:"tags,omitempty"`
+	// for meta update
+	MetaDiff *comm.MetaDiff `json:"metaUp,omitempty" swaggerignore:"true"`
+} // @name capabilitySet
+
+func (z *Capability) SetWith(o CapabilitySet) {
+	if o.OperationID != nil && z.OperationID != *o.OperationID {
+		z.LogChangeValue("operation_id", z.OperationID, o.OperationID)
+		z.OperationID = *o.OperationID
+	}
+	if o.Endpoint != nil && z.Endpoint != *o.Endpoint {
+		z.LogChangeValue("endpoint", z.Endpoint, o.Endpoint)
+		z.Endpoint = *o.Endpoint
+	}
+	if o.Method != nil && z.Method != *o.Method {
+		z.LogChangeValue("method", z.Method, o.Method)
+		z.Method = *o.Method
+	}
+	if o.Summary != nil && z.Summary != *o.Summary {
+		z.LogChangeValue("summary", z.Summary, o.Summary)
+		z.Summary = *o.Summary
+	}
+	if o.Description != nil && z.Description != *o.Description {
+		z.LogChangeValue("description", z.Description, o.Description)
+		z.Description = *o.Description
+	}
+	if o.Parameters != nil {
+		z.LogChangeValue("parameters", z.Parameters, o.Parameters)
+		z.Parameters = *o.Parameters
+	}
+	if o.Responses != nil && z.Responses != *o.Responses {
+		z.LogChangeValue("responses", z.Responses, o.Responses)
+		z.Responses = *o.Responses
+	}
+	if o.Tags != nil {
+		z.LogChangeValue("tags", z.Tags, o.Tags)
+		z.Tags = *o.Tags
+	}
+	if o.MetaDiff != nil && z.MetaUp(o.MetaDiff) {
+		z.SetChange("meta")
+	}
+}
+func (in *CapabilityBasic) MetaAddKVs(args ...any) *CapabilityBasic {
+	in.MetaDiff = comm.MetaDiffAddKVs(in.MetaDiff, args...)
+	return in
+}
+func (in *CapabilitySet) MetaAddKVs(args ...any) *CapabilitySet {
+	in.MetaDiff = comm.MetaDiffAddKVs(in.MetaDiff, args...)
+	return in
+}
+
+// consts of CapabilityVector API
+const (
+	CapabilityVectorTable = "api_capability_vector"
+	CapabilityVectorAlias = "cv"
+	CapabilityVectorLabel = "capabilityVector"
+	CapabilityVectorTypID = "capabilityCapabilityVector"
+)
+
+// CapabilityVector API 能力向量
+type CapabilityVector struct {
+	comm.BaseModel `bun:"table:api_capability_vector,alias:cv" json:"-"`
+
+	comm.DefaultModel
+
+	CapabilityVectorBasic
+
+	comm.MetaField
+} // @name capabilityCapabilityVector
+
+type CapabilityVectorBasic struct {
+	// 关联的 Capability ID
+	CapID oid.OID `bson:"capID" bun:"cap_id,notnull" extensions:"x-order=A" json:"capID" pg:"cap_id,notnull" swaggertype:"string"`
+	// 主题 基于 summary + description 等生成
+	Subject string `bson:"subject" bun:"subject,notnull,type:text" extensions:"x-order=B" form:"subject" json:"subject" pg:"subject,notnull,type:text"`
+	// 语义向量 1024 维
+	Vector corpus.Vector `bson:"vector" bun:"embedding,notnull,type:vector(1024)" extensions:"x-order=C" json:"vector" pg:"embedding,notnull,type:vector(1024)"`
+	// for meta update
+	MetaDiff *comm.MetaDiff `bson:"-" bun:"-" json:"metaUp,omitempty" pg:"-" swaggerignore:"true"`
+} // @name capabilityCapabilityVectorBasic
+
+type CapabilityVectors []CapabilityVector
+
+// Creating function call to it's inner fields defined hooks
+func (z *CapabilityVector) Creating() error {
+	if z.IsZeroID() {
+		z.SetID(oid.NewID(oid.OtEvent))
+	}
+
+	return z.DefaultModel.Creating()
+}
+func NewCapabilityVectorWithBasic(in CapabilityVectorBasic) *CapabilityVector {
+	obj := &CapabilityVector{
+		CapabilityVectorBasic: in,
+	}
+	_ = obj.MetaUp(in.MetaDiff)
+	return obj
+}
+func NewCapabilityVectorWithID(id any) *CapabilityVector {
+	obj := new(CapabilityVector)
+	_ = obj.SetID(id)
+	return obj
+}
+func (_ *CapabilityVector) IdentityLabel() string { return CapabilityVectorLabel }
+func (_ *CapabilityVector) IdentityModel() string { return CapabilityVectorTypID }
+func (_ *CapabilityVector) IdentityTable() string { return CapabilityVectorTable }
+func (_ *CapabilityVector) IdentityAlias() string { return CapabilityVectorAlias }
+
+type CapabilityVectorSet struct {
+	// 关联的 Capability ID
+	CapID *string `extensions:"x-order=A" json:"capID"`
+	// 主题 基于 summary + description 等生成
+	Subject *string `extensions:"x-order=B" json:"subject"`
+	// 语义向量 1024 维
+	Vector *corpus.Vector `extensions:"x-order=C" json:"vector"`
+	// for meta update
+	MetaDiff *comm.MetaDiff `json:"metaUp,omitempty" swaggerignore:"true"`
+} // @name capabilityCapabilityVectorSet
+
+func (z *CapabilityVector) SetWith(o CapabilityVectorSet) {
+	if o.CapID != nil {
+		if id := oid.Cast(*o.CapID); z.CapID != id {
+			z.LogChangeValue("cap_id", z.CapID, id)
+			z.CapID = id
+		}
+	}
+	if o.Subject != nil && z.Subject != *o.Subject {
+		z.LogChangeValue("subject", z.Subject, o.Subject)
+		z.Subject = *o.Subject
+	}
+	if o.Vector != nil {
+		z.LogChangeValue("embedding", z.Vector, o.Vector)
+		z.Vector = *o.Vector
+	}
+	if o.MetaDiff != nil && z.MetaUp(o.MetaDiff) {
+		z.SetChange("meta")
+	}
+}
+func (in *CapabilityVectorBasic) MetaAddKVs(args ...any) *CapabilityVectorBasic {
+	in.MetaDiff = comm.MetaDiffAddKVs(in.MetaDiff, args...)
+	return in
+}
+func (in *CapabilityVectorSet) MetaAddKVs(args ...any) *CapabilityVectorSet {
+	in.MetaDiff = comm.MetaDiffAddKVs(in.MetaDiff, args...)
+	return in
+}
+
+// consts of SwaggerParam swagger
+const (
+	SwaggerParamLabel = "swaggerParam"
+	SwaggerParamTypID = "capabilitySwaggerParam"
+)
+
+// SwaggerParam swagger 参数定义
+type SwaggerParam struct {
+	// 参数类型
+	Type string `extensions:"x-order=A" form:"type" json:"type" yaml:"type"`
+	// 参数描述
+	Description string `extensions:"x-order=B" form:"description" json:"description" yaml:"description"`
+	// 参数名称
+	Name string `extensions:"x-order=C" form:"name" json:"name" yaml:"name"`
+	// 参数位置 header/query/body/path
+	In string `extensions:"x-order=D" form:"in" json:"in" yaml:"in"`
+	// 是否必填
+	Required bool `extensions:"x-order=E" form:"required" json:"required" yaml:"required"`
+	// 参数示例
+	Example string `extensions:"x-order=F" form:"example" json:"example,omitempty" yaml:"example"`
+	// schema 定义
+	Schema any `extensions:"x-order=G" json:"schema,omitempty" yaml:"schema"`
+} // @name capabilitySwaggerParam

--- a/pkg/models/capability/capability_x.go
+++ b/pkg/models/capability/capability_x.go
@@ -1,0 +1,94 @@
+package capability
+
+import (
+	"strings"
+
+	"github.com/liut/morign/pkg/models/aigc"
+)
+
+// CapabilityMatch 能力匹配结果 - 复用 MatchResult
+type CapabilityMatch = aigc.MatchResult
+
+// GetSubject returns the capability subject (tags + summary + description)
+func (z *CapabilityBasic) GetSubject() string {
+	var parts []string
+	if len(z.Tags) > 0 {
+		parts = append(parts, z.Tags[0])
+	}
+	if z.Summary != "" {
+		parts = append(parts, z.Summary)
+	}
+	if z.Description != "" {
+		parts = append(parts, z.Description)
+	}
+	return strings.Join(parts, " ")
+}
+
+// GetSubjectWithParams returns subject enhanced with parameters info
+func (z *CapabilityBasic) GetSubjectWithParams() string {
+	subject := z.GetSubject()
+	// Future: parse parameters and responses to extract key fields
+	return subject
+}
+
+func (z Capabilities) Endpoints() []string {
+	out := make([]string, len(z))
+	for i := range z {
+		out[i] = z[i].Endpoint
+	}
+	return out
+}
+
+// FilterParams removes parameters with the specified name from the list
+func FilterParams(params []SwaggerParam, excludeName string) []SwaggerParam {
+	if len(params) == 0 {
+		return params
+	}
+	filtered := make([]SwaggerParam, 0, len(params))
+	for _, p := range params {
+		if p.Name != excludeName {
+			filtered = append(filtered, p)
+		}
+	}
+	return filtered
+}
+
+// EnrichSortableFields extracts <sortable>field1,field2...</sortable> from Description
+// and appends the sortable fields info to Parameters[sort].Description if sort param exists
+func (z *CapabilityBasic) EnrichSortableFields() {
+	const sortablePrefix = "<sortable>"
+	const sortableSuffix = "</sortable>"
+
+	start := strings.Index(z.Description, sortablePrefix)
+	if start == -1 {
+		return
+	}
+
+	end := strings.Index(z.Description[start:], sortableSuffix)
+	if end == -1 {
+		return
+	}
+	end += start + len(sortableSuffix)
+
+	sortableContent := z.Description[start+len(sortablePrefix) : end-len(sortableSuffix)]
+	sortableFields := strings.Split(sortableContent, ",")
+
+	var sortParam *SwaggerParam
+	for i := range z.Parameters {
+		if z.Parameters[i].Name == "sort" {
+			sortParam = &z.Parameters[i]
+			break
+		}
+	}
+	if sortParam == nil {
+		return
+	}
+
+	existingDesc := sortParam.Description
+	if existingDesc != "" && !strings.HasSuffix(existingDesc, " ") {
+		sortParam.Description += " "
+	}
+	sortParam.Description += "Sortable fields: " + strings.Join(sortableFields, ", ")
+
+	z.Description = z.Description[:start] + z.Description[end:]
+}

--- a/pkg/models/capability/capability_x_test.go
+++ b/pkg/models/capability/capability_x_test.go
@@ -1,0 +1,112 @@
+package capability
+
+import "testing"
+
+func TestCapability_EnrichSortableFields(t *testing.T) {
+	tests := []struct {
+		name            string
+		description     string
+		parameters      []SwaggerParam
+		wantSortDesc    string
+		wantDescWithout string
+	}{
+		{
+			name:        "normal case",
+			description: "List users <sortable>name,email,created_at</sortable> API",
+			parameters: []SwaggerParam{
+				{Name: "limit", Description: "Page size"},
+				{Name: "sort", Description: "Sort field"},
+			},
+			wantSortDesc:    "Sort field Sortable fields: name, email, created_at",
+			wantDescWithout: "List users  API",
+		},
+		{
+			name:        "sortable at start",
+			description: "<sortable>id,name</sortable> Get all items",
+			parameters: []SwaggerParam{
+				{Name: "sort", Description: "Sort by"},
+			},
+			wantSortDesc:    "Sort by Sortable fields: id, name",
+			wantDescWithout: " Get all items",
+		},
+		{
+			name:        "sortable at end",
+			description: "Get items <sortable>price,quantity</sortable>",
+			parameters: []SwaggerParam{
+				{Name: "sort", Description: ""},
+			},
+			wantSortDesc:    "Sortable fields: price, quantity",
+			wantDescWithout: "Get items ",
+		},
+		{
+			name:        "no sortable tag",
+			description: "Just a normal description",
+			parameters: []SwaggerParam{
+				{Name: "sort", Description: "Sort field"},
+			},
+			wantSortDesc:    "Sort field",
+			wantDescWithout: "Just a normal description",
+		},
+		{
+			name:        "no sort parameter",
+			description: "List users <sortable>name,email</sortable> API",
+			parameters: []SwaggerParam{
+				{Name: "limit", Description: "Page size"},
+			},
+			wantSortDesc:    "",
+			wantDescWithout: "List users <sortable>name,email</sortable> API",
+		},
+		{
+			name:        "unclosed sortable tag",
+			description: "List users <sortable>name,email",
+			parameters: []SwaggerParam{
+				{Name: "sort", Description: "Sort field"},
+			},
+			wantSortDesc:    "Sort field",
+			wantDescWithout: "List users <sortable>name,email",
+		},
+		{
+			name:        "empty sortable content",
+			description: "List users <sortable></sortable> API",
+			parameters: []SwaggerParam{
+				{Name: "sort", Description: ""},
+			},
+			wantSortDesc:    "Sortable fields: ",
+			wantDescWithout: "List users  API",
+		},
+		{
+			name:        "single field",
+			description: "Get items <sortable>id</sortable>",
+			parameters: []SwaggerParam{
+				{Name: "sort", Description: "Sort by"},
+			},
+			wantSortDesc:    "Sort by Sortable fields: id",
+			wantDescWithout: "Get items ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &CapabilityBasic{
+				Description: tt.description,
+				Parameters:  tt.parameters,
+			}
+			c.EnrichSortableFields()
+
+			var sortDesc string
+			for _, p := range c.Parameters {
+				if p.Name == "sort" {
+					sortDesc = p.Description
+					break
+				}
+			}
+			if sortDesc != tt.wantSortDesc {
+				t.Errorf("sort param description = %q, want %q", sortDesc, tt.wantSortDesc)
+			}
+
+			if c.Description != tt.wantDescWithout {
+				t.Errorf("Description = %q, want %q", c.Description, tt.wantDescWithout)
+			}
+		})
+	}
+}

--- a/pkg/services/llm/anthropic.go
+++ b/pkg/services/llm/anthropic.go
@@ -374,7 +374,7 @@ func (p *anthropicProvider) handleStreamEvent(event streamEvent, currentText *st
 					event.Delta.PartialJSON...,
 				)
 			}
-			logger().Debugw("input json", "delta", event.Delta, "toolCalls", currentToolCalls)
+			// logger().Debugw("input json", "delta", event.Delta, "toolCalls", currentToolCalls)
 		}
 	case "content_block_stop":
 		// 内容块结束

--- a/pkg/services/stores/capability_gen.go
+++ b/pkg/services/stores/capability_gen.go
@@ -1,0 +1,127 @@
+// This file is generated - Do Not Edit.
+
+package stores
+
+import (
+	"context"
+
+	"github.com/liut/morign/pkg/models/capability"
+)
+
+// type CapCapability = capability.Capability
+// type CapCapabilityVector = capability.CapabilityVector
+// type SwaggerParam = capability.SwaggerParam
+
+func init() {
+	RegisterModel((*capability.Capability)(nil), (*capability.CapabilityVector)(nil))
+}
+
+type CapabilityStore interface {
+	CapabilityStoreX
+
+	ListCapability(ctx context.Context, spec *CapCapabilitySpec) (data capability.Capabilities, total int, err error)
+	GetCapability(ctx context.Context, id string) (obj *capability.Capability, err error)
+	CreateCapability(ctx context.Context, in capability.CapabilityBasic) (obj *capability.Capability, err error)
+	UpdateCapability(ctx context.Context, id string, in capability.CapabilitySet) error
+	DeleteCapability(ctx context.Context, id string) error
+
+	ListCapabilityVector(ctx context.Context, spec *CapCapabilityVectorSpec) (data capability.CapabilityVectors, total int, err error)
+	GetCapabilityVector(ctx context.Context, id string) (obj *capability.CapabilityVector, err error)
+	CreateCapabilityVector(ctx context.Context, in capability.CapabilityVectorBasic) (obj *capability.CapabilityVector, err error)
+}
+
+type CapCapabilitySpec struct {
+	PageSpec
+	ModelSpec
+
+	// operationId（可为空，公开接口无此字段）
+	OperationID string `extensions:"x-order=A" form:"operationID" json:"operationID"`
+	// API 路径，如 /api/accounts/{id}
+	Endpoint string `extensions:"x-order=B" form:"endpoint" json:"endpoint"`
+	// HTTP 方法 GET/POST/PUT/DELETE 等
+	Method string `extensions:"x-order=C" form:"method" json:"method"`
+}
+
+func (spec *CapCapabilitySpec) Sift(q *ormQuery) *ormQuery {
+	q = spec.ModelSpec.Sift(q)
+	q, _ = siftEqual(q, "operation_id", spec.OperationID, false)
+	q, _ = siftMatch(q, "endpoint", spec.Endpoint, false)
+	q, _ = siftEqual(q, "method", spec.Method, false)
+
+	return q
+}
+
+type CapCapabilityVectorSpec struct {
+	PageSpec
+	ModelSpec
+
+	// 关联的 Capability ID
+	CapID string `extensions:"x-order=A" form:"capID" json:"capID"`
+}
+
+func (spec *CapCapabilityVectorSpec) Sift(q *ormQuery) *ormQuery {
+	q = spec.ModelSpec.Sift(q)
+	q, _ = siftOID(q, "cap_id", spec.CapID, false)
+
+	return q
+}
+
+type capabilityStore struct {
+	w *Wrap
+}
+
+func (s *capabilityStore) ListCapability(ctx context.Context, spec *CapCapabilitySpec) (data capability.Capabilities, total int, err error) {
+	total, err = s.w.db.ListModel(ctx, spec, &data)
+	if err == nil {
+		err = s.afterListCapability(ctx, spec, data)
+	}
+	return
+}
+func (s *capabilityStore) GetCapability(ctx context.Context, id string) (obj *capability.Capability, err error) {
+	obj = new(capability.Capability)
+	err = dbGetWithPKID(ctx, s.w.db, obj, id)
+	if err == nil {
+		err = s.afterLoadCapability(ctx, obj)
+	}
+	return
+}
+func (s *capabilityStore) CreateCapability(ctx context.Context, in capability.CapabilityBasic) (obj *capability.Capability, err error) {
+	obj = capability.NewCapabilityWithBasic(in)
+	dbMetaUp(ctx, s.w.db, obj)
+	err = dbInsert(ctx, s.w.db, obj)
+	if err == nil {
+		err = s.afterCreatedCapability(ctx, obj)
+	}
+	return
+}
+func (s *capabilityStore) UpdateCapability(ctx context.Context, id string, in capability.CapabilitySet) error {
+	exist := new(capability.Capability)
+	if err := dbGetWithPKID(ctx, s.w.db, exist, id); err != nil {
+		return err
+	}
+	exist.SetIsUpdate(true)
+	exist.SetWith(in)
+	dbMetaUp(ctx, s.w.db, exist)
+	return dbUpdate(ctx, s.w.db, exist)
+}
+func (s *capabilityStore) DeleteCapability(ctx context.Context, id string) error {
+	obj := new(capability.Capability)
+	return s.w.db.DeleteModel(ctx, obj, id)
+}
+
+func (s *capabilityStore) ListCapabilityVector(ctx context.Context, spec *CapCapabilityVectorSpec) (data capability.CapabilityVectors, total int, err error) {
+	total, err = s.w.db.ListModel(ctx, spec, &data)
+	return
+}
+func (s *capabilityStore) GetCapabilityVector(ctx context.Context, id string) (obj *capability.CapabilityVector, err error) {
+	obj = new(capability.CapabilityVector)
+	err = dbGetWithPKID(ctx, s.w.db, obj, id)
+
+	return
+}
+func (s *capabilityStore) CreateCapabilityVector(ctx context.Context, in capability.CapabilityVectorBasic) (obj *capability.CapabilityVector, err error) {
+	obj = capability.NewCapabilityVectorWithBasic(in)
+	dbMetaUp(ctx, s.w.db, obj)
+	err = dbInsert(ctx, s.w.db, obj)
+	return
+}

--- a/pkg/services/stores/capability_invoker.go
+++ b/pkg/services/stores/capability_invoker.go
@@ -1,0 +1,106 @@
+package stores
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/spf13/cast"
+)
+
+// CapabilityInvoker invokes Bus API calls with path parameter substitution.
+type CapabilityInvoker struct {
+	httpClient *http.Client
+	baseURL    string
+}
+
+// NewCapabilityInvoker creates a CapabilityInvoker with the given Bus API base URL.
+func NewCapabilityInvoker(baseURL string) *CapabilityInvoker {
+	return &CapabilityInvoker{
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		baseURL:    strings.TrimSuffix(baseURL, "/"),
+	}
+}
+
+// Invoke makes an HTTP request to the Bus API.
+func (inv *CapabilityInvoker) Invoke(ctx context.Context, method, endpoint string, params map[string]any) (*http.Response, error) {
+	method = strings.ToUpper(method)
+
+	// Build URL and body
+	reqURL, body, err := inv.buildRequestData(method, endpoint, params)
+	if err != nil {
+		return nil, err
+	}
+
+	logger().Infow("invoking api", "method", method, "url", reqURL, "params", params)
+
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	if tk := OAuthTokenFromContext(ctx); len(tk) > 0 {
+		req.Header.Set("Authorization", "Bearer "+tk)
+	}
+
+	return inv.httpClient.Do(req)
+}
+
+// buildRequestData handles path parameter substitution, query string construction, and JSON body generation.
+func (inv *CapabilityInvoker) buildRequestData(method, endpoint string, params map[string]any) (string, io.Reader, error) {
+	fullURL := inv.baseURL + endpoint
+	if len(params) == 0 {
+		return fullURL, nil, nil
+	}
+
+	u, err := url.Parse(fullURL)
+	if err != nil {
+		return "", nil, fmt.Errorf("parse url: %w", err)
+	}
+
+	// 1. Substitute path parameters, collect remaining params
+	remaining := make(map[string]any)
+	path := u.Path
+	for k, v := range params {
+		placeholder := "{" + k + "}"
+		if strings.Contains(path, placeholder) {
+			path = strings.ReplaceAll(path, placeholder, cast.ToString(v))
+		} else {
+			remaining[k] = v
+		}
+	}
+	u.Path = path
+
+	if len(remaining) == 0 {
+		return u.String(), nil, nil
+	}
+
+	// 2. Route remaining params based on HTTP method
+	var body io.Reader
+	switch method {
+	case http.MethodGet, http.MethodDelete:
+		// GET and DELETE: remaining params become query string
+		q := u.Query()
+		for k, v := range remaining {
+			q.Add(k, cast.ToString(v))
+		}
+		u.RawQuery = q.Encode()
+
+	case http.MethodPost, http.MethodPut, http.MethodPatch:
+		// POST, PUT, PATCH: remaining params become JSON body
+		data, err := json.Marshal(remaining)
+		if err != nil {
+			return "", nil, fmt.Errorf("marshal params: %w", err)
+		}
+		body = bytes.NewReader(data)
+	}
+
+	return u.String(), body, nil
+}

--- a/pkg/services/stores/capability_invoker_test.go
+++ b/pkg/services/stores/capability_invoker_test.go
@@ -1,0 +1,240 @@
+package stores
+
+import (
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildRequestData(t *testing.T) {
+	inv := &CapabilityInvoker{baseURL: "http://localhost:8080"}
+
+	tests := []struct {
+		name     string
+		method   string
+		endpoint string
+		params   map[string]any
+		wantURL  string
+		wantBody string
+	}{
+		{
+			name:     "GET with path param only",
+			method:   http.MethodGet,
+			endpoint: "/api/a1/companies/{id}",
+			params:   map[string]any{"id": "co-123"},
+			wantURL:  "http://localhost:8080/api/a1/companies/co-123",
+			wantBody: "",
+		},
+		{
+			name:     "GET with path param and query param",
+			method:   http.MethodGet,
+			endpoint: "/api/a1/companies/{id}",
+			params:   map[string]any{"id": "co-123", "name": "test"},
+			wantURL:  "http://localhost:8080/api/a1/companies/co-123?name=test",
+			wantBody: "",
+		},
+		{
+			name:     "GET with query param only",
+			method:   http.MethodGet,
+			endpoint: "/api/a1/companies",
+			params:   map[string]any{"name": "test"},
+			wantURL:  "http://localhost:8080/api/a1/companies?name=test",
+			wantBody: "",
+		},
+		{
+			name:     "DELETE with path param and query param",
+			method:   http.MethodDelete,
+			endpoint: "/api/a1/companies/{id}",
+			params:   map[string]any{"id": "co-123", "name": "test"},
+			wantURL:  "http://localhost:8080/api/a1/companies/co-123?name=test",
+			wantBody: "",
+		},
+		{
+			name:     "DELETE with query param only",
+			method:   http.MethodDelete,
+			endpoint: "/api/a1/companies",
+			params:   map[string]any{"name": "test", "status": "active"},
+			wantURL:  "http://localhost:8080/api/a1/companies?name=test&status=active",
+			wantBody: "",
+		},
+		{
+			name:     "POST with path param and body",
+			method:   http.MethodPost,
+			endpoint: "/api/a1/companies/{id}/users",
+			params:   map[string]any{"id": "co-123", "name": "test", "role": "admin"},
+			wantURL:  "http://localhost:8080/api/a1/companies/co-123/users",
+			wantBody: `{"name":"test","role":"admin"}`,
+		},
+		{
+			name:     "POST with body only",
+			method:   http.MethodPost,
+			endpoint: "/api/a1/companies",
+			params:   map[string]any{"name": "test", "status": "active"},
+			wantURL:  "http://localhost:8080/api/a1/companies",
+			wantBody: `{"name":"test","status":"active"}`,
+		},
+		{
+			name:     "PUT with path param and body",
+			method:   http.MethodPut,
+			endpoint: "/api/a1/companies/{id}",
+			params:   map[string]any{"id": "co-123", "name": "updated"},
+			wantURL:  "http://localhost:8080/api/a1/companies/co-123",
+			wantBody: `{"name":"updated"}`,
+		},
+		{
+			name:     "PATCH with body only",
+			method:   http.MethodPatch,
+			endpoint: "/api/a1/companies/{id}",
+			params:   map[string]any{"id": "co-123", "name": "patched"},
+			wantURL:  "http://localhost:8080/api/a1/companies/co-123",
+			wantBody: `{"name":"patched"}`,
+		},
+		{
+			name:     "multiple path params",
+			method:   http.MethodGet,
+			endpoint: "/api/a1/companies/{id}/users/{userId}",
+			params:   map[string]any{"id": "co-123", "userId": "u-456"},
+			wantURL:  "http://localhost:8080/api/a1/companies/co-123/users/u-456",
+			wantBody: "",
+		},
+		{
+			name:     "multiple path params with remaining",
+			method:   http.MethodPost,
+			endpoint: "/api/a1/companies/{id}/users/{userId}",
+			params:   map[string]any{"id": "co-123", "userId": "u-456", "name": "test"},
+			wantURL:  "http://localhost:8080/api/a1/companies/co-123/users/u-456",
+			wantBody: `{"name":"test"}`,
+		},
+		{
+			name:     "empty params",
+			method:   http.MethodGet,
+			endpoint: "/api/a1/companies",
+			params:   map[string]any{},
+			wantURL:  "http://localhost:8080/api/a1/companies",
+			wantBody: "",
+		},
+		{
+			name:     "no matching path param - params go to query for GET",
+			method:   http.MethodGet,
+			endpoint: "/api/a1/companies/{id}",
+			params:   map[string]any{"name": "test"},
+			wantURL:  "http://localhost:8080/api/a1/companies/%7Bid%7D?name=test",
+			wantBody: "",
+		},
+		{
+			name:     "lowercase method normalized",
+			method:   "get",
+			endpoint: "/api/a1/companies/{id}",
+			params:   map[string]any{"id": "co-123"},
+			wantURL:  "http://localhost:8080/api/a1/companies/co-123",
+			wantBody: "",
+		},
+		{
+			name:     "boolean and number params - GET",
+			method:   http.MethodGet,
+			endpoint: "/api/a1/companies",
+			params:   map[string]any{"active": true, "limit": 10},
+			wantURL:  "http://localhost:8080/api/a1/companies?active=true&limit=10",
+			wantBody: "",
+		},
+		{
+			name:     "boolean and number params - POST",
+			method:   http.MethodPost,
+			endpoint: "/api/a1/companies",
+			params:   map[string]any{"active": true, "limit": 10},
+			wantURL:  "http://localhost:8080/api/a1/companies",
+			wantBody: `{"active":true,"limit":10}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotURL, gotBody, err := inv.buildRequestData(tt.method, tt.endpoint, tt.params)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantURL, gotURL)
+
+			if tt.wantBody == "" {
+				assert.Nil(t, gotBody)
+			} else {
+				require.NotNil(t, gotBody)
+				bodyBytes, err := io.ReadAll(gotBody)
+				require.NoError(t, err)
+				assert.JSONEq(t, tt.wantBody, string(bodyBytes))
+			}
+		})
+	}
+}
+
+func TestBuildRequestData_EdgeCases(t *testing.T) {
+	inv := &CapabilityInvoker{baseURL: "http://localhost:8080"}
+
+	t.Run("path param with special characters", func(t *testing.T) {
+		urlStr, body, err := inv.buildRequestData(http.MethodGet, "/api/test/{id}", map[string]any{"id": "co-123/abc"})
+		require.NoError(t, err)
+		assert.Equal(t, "http://localhost:8080/api/test/co-123/abc", urlStr)
+		assert.Nil(t, body)
+	})
+
+	t.Run("path param with empty string value", func(t *testing.T) {
+		urlStr, body, err := inv.buildRequestData(http.MethodGet, "/api/test/{id}", map[string]any{"id": ""})
+		require.NoError(t, err)
+		assert.Equal(t, "http://localhost:8080/api/test/", urlStr)
+		assert.Nil(t, body)
+	})
+
+	t.Run("query param with special characters", func(t *testing.T) {
+		urlStr, _, err := inv.buildRequestData(http.MethodGet, "/api/test", map[string]any{"q": "hello world"})
+		require.NoError(t, err)
+		assert.Equal(t, "http://localhost:8080/api/test?q=hello+world", urlStr)
+	})
+
+	t.Run("nil params treated as empty", func(t *testing.T) {
+		urlStr, body, err := inv.buildRequestData(http.MethodGet, "/api/test", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "http://localhost:8080/api/test", urlStr)
+		assert.Nil(t, body)
+	})
+
+	t.Run("array params in body", func(t *testing.T) {
+		urlStr, body, err := inv.buildRequestData(http.MethodPost, "/api/test", map[string]any{"ids": []int{1, 2, 3}})
+		require.NoError(t, err)
+		assert.Equal(t, "http://localhost:8080/api/test", urlStr)
+		bodyBytes, _ := io.ReadAll(body)
+		assert.JSONEq(t, `{"ids":[1,2,3]}`, string(bodyBytes))
+	})
+
+	t.Run("map params in body", func(t *testing.T) {
+		urlStr, body, err := inv.buildRequestData(http.MethodPost, "/api/test", map[string]any{"metadata": map[string]any{"key": "value"}})
+		require.NoError(t, err)
+		assert.Equal(t, "http://localhost:8080/api/test", urlStr)
+		bodyBytes, _ := io.ReadAll(body)
+		assert.JSONEq(t, `{"metadata":{"key":"value"}}`, string(bodyBytes))
+	})
+
+	t.Run("empty body for POST when no remaining params", func(t *testing.T) {
+		urlStr, body, err := inv.buildRequestData(http.MethodPost, "/api/test/{id}", map[string]any{"id": "123"})
+		require.NoError(t, err)
+		assert.Equal(t, "http://localhost:8080/api/test/123", urlStr)
+		assert.Nil(t, body)
+	})
+
+	t.Run("PUT with query string-like path", func(t *testing.T) {
+		urlStr, body, err := inv.buildRequestData(http.MethodPut, "/api/test", map[string]any{"name": "test"})
+		require.NoError(t, err)
+		assert.Equal(t, "http://localhost:8080/api/test", urlStr)
+		require.NotNil(t, body)
+		bodyBytes, _ := io.ReadAll(body)
+		assert.JSONEq(t, `{"name":"test"}`, string(bodyBytes))
+	})
+
+	t.Run("all HTTP methods supported", func(t *testing.T) {
+		methods := []string{http.MethodGet, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete}
+		for _, method := range methods {
+			_, _, err := inv.buildRequestData(method, "/api/test", map[string]any{"key": "value"})
+			require.NoError(t, err, "method %s should not error", method)
+		}
+	})
+}

--- a/pkg/services/stores/capability_x.go
+++ b/pkg/services/stores/capability_x.go
@@ -1,0 +1,432 @@
+package stores
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/cupogo/andvari/models/oid"
+	"github.com/liut/morign/pkg/models/capability"
+	"github.com/liut/morign/pkg/models/corpus"
+	"github.com/liut/morign/pkg/models/mcps"
+	"github.com/liut/morign/pkg/settings"
+	"github.com/liut/morign/pkg/utils/words"
+)
+
+// CapabilityStoreX is the capability storage extension interface
+type CapabilityStoreX interface {
+	CountCapability(ctx context.Context) (int, error)
+	GetCapabilityWith(ctx context.Context, method, endpoint string) (*capability.Capability, error)
+	ImportCapabilities(ctx context.Context, r io.Reader, lw io.Writer) error
+	SyncEmbeddingCapabilities(ctx context.Context, spec *CapCapabilitySpec) error
+	MatchCapabilities(ctx context.Context, ms MatchSpec) (data capability.Capabilities, err error)
+	MatchVectorWith(ctx context.Context, vec corpus.Vector, threshold float32, limit int) (data []capability.CapabilityMatch, err error)
+	InvokerForMatch() mcps.Invoker
+	InvokerForInvoke(invoker *CapabilityInvoker) mcps.Invoker
+}
+
+// swaggerDoc represents a swagger document structure
+type swaggerDoc struct {
+	Swagger string `json:"swagger" yaml:"swagger"`
+	Info    struct {
+		Title string `json:"title" yaml:"title"`
+	} `json:"info" yaml:"info"`
+	Paths map[string]map[string]struct {
+		OperationID string                    `json:"operationId" yaml:"operationId"`
+		Summary     string                    `json:"summary" yaml:"summary"`
+		Description string                    `json:"description" yaml:"description"`
+		Parameters  []capability.SwaggerParam `json:"parameters" yaml:"parameters"`
+		Responses   map[string]any            `json:"responses" yaml:"responses"`
+		Tags        []string                  `json:"tags" yaml:"tags"`
+	} `json:"paths" yaml:"paths"`
+}
+
+// decodeSwaggerDoc decodes swagger document from JSON or YAML format
+func decodeSwaggerDoc(r io.Reader) (*swaggerDoc, error) {
+	// Read all content first
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("read data: %w", err)
+	}
+
+	doc := new(swaggerDoc)
+	// Try JSON first
+	if err := json.Unmarshal(data, doc); err == nil && doc.Paths != nil {
+		return doc, nil
+	}
+
+	// Try YAML
+	if err := yaml.Unmarshal(data, doc); err != nil {
+		return nil, fmt.Errorf("decode swagger (tried JSON and YAML): %w", err)
+	}
+	return doc, nil
+}
+
+func (s *capabilityStore) afterCreatedCapability(ctx context.Context, obj *capability.Capability) error {
+	subject := obj.GetSubject()
+	cvb := capability.CapabilityVectorBasic{
+		CapID:   obj.ID,
+		Subject: subject,
+	}
+	vec, err := GetEmbedding(ctx, cvb.Subject)
+	if err != nil {
+		return err
+	}
+	if len(vec) > 0 {
+		cvb.Vector = vec
+	}
+
+	_, err = s.CreateCapabilityVector(ctx, cvb)
+	if err != nil {
+		logger().Infow("create capability vector fail", "cvb", &cvb, "err", err)
+		return err
+	}
+	return nil
+}
+
+// afterLoadCapability implements after load hook
+func (s *capabilityStore) afterLoadCapability(ctx context.Context, obj *capability.Capability) error {
+	return nil
+}
+
+// afterListCapability implements after list hook
+func (s *capabilityStore) afterListCapability(ctx context.Context, spec *CapCapabilitySpec, data capability.Capabilities) error {
+	return nil
+}
+
+func (s *capabilityStore) CountCapability(ctx context.Context) (int, error) {
+	spec := &CapCapabilitySpec{}
+	spec.Limit = -1
+	_, count, err := s.ListCapability(ctx, spec)
+	return count, err
+}
+
+func (s *capabilityStore) GetCapabilityWith(ctx context.Context, method, endpoint string) (*capability.Capability, error) {
+	obj := new(capability.Capability)
+	err := dbGet(ctx, s.w.db, obj, "method = ? AND endpoint = ?", strings.ToUpper(method), endpoint)
+	if err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+// MatchVectorWith matches capabilities using vector
+func (s *capabilityStore) MatchVectorWith(ctx context.Context, vec corpus.Vector, threshold float32, limit int) (data []capability.CapabilityMatch, err error) {
+	if len(vec) != corpus.VectorLen {
+		logger().Infow("mismatch length of vector", "a", len(vec), "b", corpus.VectorLen)
+		return
+	}
+	logger().Debugw("match capability with", "vec", vec[0:5])
+	err = s.w.db.NewRaw("SELECT * FROM vector_match_capability_4(?, ?, ?)", vec, threshold, limit).
+		Scan(ctx, &data)
+	if err != nil {
+		logger().Infow("match capability vector fail", "threshold", threshold, "limit", limit, "err", err)
+	} else {
+		logger().Debugw("match capability vector ok", "threshold", threshold, "limit", limit, "data", data)
+	}
+	return
+}
+
+// MatchCapabilities matches capabilities by query
+func (s *capabilityStore) MatchCapabilities(ctx context.Context, ms MatchSpec) (data capability.Capabilities, err error) {
+	ms.setDefaults()
+
+	var subject string
+	if ms.SkipKeywords {
+		subject = ms.Query
+	} else {
+		subject, err = GetSummary(ctx, ms.Query, GetTemplateForKeyword())
+		if err != nil {
+			return
+		}
+	}
+
+	if len(subject) == 0 {
+		logger().Infow("empty subject", "spec", ms)
+		return
+	}
+
+	vec, err := GetEmbedding(ctx, subject)
+	if err != nil {
+		logger().Infow("GetEmbedding fail", "err", err)
+		return
+	}
+	if len(vec) != corpus.VectorLen {
+		logger().Infow("embedding length mismatch", "a", len(vec), "b", corpus.VectorLen)
+		return
+	}
+
+	matches, err := s.MatchVectorWith(ctx, vec, ms.Threshold, ms.Limit)
+	if err != nil || len(matches) == 0 {
+		logger().Infow("no match capabilities", "subj", subject)
+		return
+	}
+
+	ids := make(oid.OIDs, 0, len(matches))
+	for _, m := range matches {
+		ids = append(ids, m.DocID)
+	}
+	logger().Infow("matched", "caps", ids, "err", err)
+
+	spec := &CapCapabilitySpec{}
+	spec.IDs = ids
+	err = queryList(ctx, s.w.db, spec, &data).Scan(ctx)
+	if err != nil {
+		logger().Infow("list capabilities fail", "spec", spec, "err", err)
+	}
+
+	return
+}
+
+// SyncEmbeddingCapabilities generates vectors for capabilities
+func (s *capabilityStore) SyncEmbeddingCapabilities(ctx context.Context, spec *CapCapabilitySpec) error {
+	data, _, err := s.ListCapability(ctx, spec)
+	if err != nil {
+		return err
+	}
+
+	for _, cap := range data {
+		subject := cap.GetSubject()
+		vec, err := GetEmbedding(ctx, subject)
+		if err != nil {
+			logger().Warnw("skip capability due to embedding fail", "id", cap.ID, "err", err)
+			continue // Skip this capability, continue with next
+		}
+
+		// Check if vector already exists
+		existing := new(capability.CapabilityVector)
+		err = dbGetWithUnique(ctx, s.w.db, existing, "cap_id", cap.ID)
+		if err == nil {
+			// Update existing
+			if existing.Subject != subject {
+				logger().Infow("subject changed", "id", cap.ID, "old", existing.Subject, "new", subject)
+			}
+			existing.SetWith(capability.CapabilityVectorSet{
+				Subject: &subject,
+				Vector:  &vec,
+			})
+			if err = dbUpdate(ctx, s.w.db, existing); err != nil {
+				return err
+			}
+		} else {
+			// Create new
+			cvb := capability.CapabilityVectorBasic{
+				CapID:   cap.ID,
+				Subject: subject,
+				Vector:  vec,
+			}
+			_, err = s.CreateCapabilityVector(ctx, cvb)
+			if err != nil {
+				logger().Warnw("create capability vector fail", "capId", cap.ID, "err", err)
+				continue
+			}
+		}
+	}
+	return nil
+}
+
+// ImportCapabilities imports capabilities from swagger document (supports both JSON and YAML formats)
+func (s *capabilityStore) ImportCapabilities(ctx context.Context, r io.Reader, lw io.Writer) error {
+	doc, err := decodeSwaggerDoc(r)
+	if err != nil {
+		logger().Infow("decode swagger fail", "err", err)
+		return err
+	}
+
+	var imported, skipped int
+	for path, methods := range doc.Paths {
+		for method, api := range methods {
+			method = strings.ToUpper(method)
+			if method == "PARAMETERS" || method == "RESOLUTIONS" {
+				continue
+			}
+
+			basic := capability.CapabilityBasic{
+				OperationID: api.OperationID,
+				Endpoint:    path,
+				Method:      method,
+				Summary:     api.Summary,
+				Description: api.Description,
+				Tags:        api.Tags,
+			}
+
+			// Assign parameters and responses (filter out token header param)
+			basic.Parameters = capability.FilterParams(api.Parameters, "token")
+			if responses, err := json.Marshal(api.Responses); err == nil {
+				basic.Responses = string(responses)
+			}
+
+			// Skip if no valid subject (no tags, summary, or description)
+			basic.EnrichSortableFields()
+			if basic.GetSubject() == "" {
+				if lw != nil {
+					fmt.Fprintf(lw, "%s %s [skipped: empty subject]\n", method, path)
+				}
+				skipped++
+				continue
+			}
+
+			// Try to find existing by method+endpoint (unique constraint)
+			existing, err := s.GetCapabilityWith(ctx, method, path)
+			if err != nil && !errors.Is(err, ErrNoRows) {
+				logger().Warnw("check existing fail", "path", path, "method", method, "err", err)
+				continue
+			}
+
+			if existing != nil && existing.ID.Valid() {
+				// Update existing
+				err = s.UpdateCapability(ctx, existing.StringID(), capability.CapabilitySet{
+					OperationID: &api.OperationID,
+					Summary:     &api.Summary,
+					Description: &api.Description,
+					Parameters:  &basic.Parameters,
+					Responses:   &basic.Responses,
+					Tags:        &api.Tags,
+				})
+				if err != nil {
+					logger().Warnw("update capability fail", "path", path, "method", method, "err", err)
+					skipped++
+					continue
+				}
+				if lw != nil {
+					fmt.Fprintf(lw, "%s %s [updated]\n", method, path)
+				}
+			} else {
+				// Create new
+				_, err = s.CreateCapability(ctx, basic)
+				if err != nil {
+					logger().Warnw("create capability fail", "path", path, "method", method, "err", err)
+					skipped++
+					continue
+				}
+				if lw != nil {
+					fmt.Fprintf(lw, "%s %s [created]\n", method, path)
+				}
+			}
+			imported++
+		}
+	}
+
+	logger().Infow("import swagger", "imported", imported, "skipped", skipped)
+	return nil
+}
+
+// InvokerForMatch returns an invoker for matching capabilities
+func (s *capabilityStore) InvokerForMatch() mcps.Invoker {
+	return func(ctx context.Context, args map[string]any) (map[string]any, error) {
+		intent, ok := args["intent"].(string)
+		if !ok || intent == "" {
+			return mcps.BuildToolErrorResult("missing required argument: intent"), nil
+		}
+
+		limit := 5
+		if l, ok := args["limit"].(float64); ok {
+			limit = int(l)
+		}
+
+		caps, err := s.MatchCapabilities(ctx, MatchSpec{
+			Query: intent,
+			Limit: limit,
+
+			SkipKeywords: true,
+		})
+		if err != nil {
+			return mcps.BuildToolErrorResult(err.Error()), nil
+		}
+		if len(caps) == 0 {
+			return mcps.BuildToolSuccessResult("No matching APIs found"), nil
+		}
+		logger().Infow("matched", "caps", len(caps), "endpoints", caps.Endpoints())
+
+		// Build result with capability details
+		result := make([]map[string]any, 0, len(caps))
+		for _, cap := range caps {
+			result = append(result, map[string]any{
+				"id":           cap.StringID(),
+				"operation_id": cap.OperationID,
+				"endpoint":     cap.Endpoint,
+				"method":       cap.Method,
+				"summary":      cap.Summary,
+				"description":  cap.Description,
+				"parameters":   cap.Parameters,
+				"subject":      cap.GetSubject(),
+			})
+		}
+		return mcps.BuildToolSuccessResult(result), nil
+	}
+}
+
+// InvokerForInvoke returns an invoker for invoking capabilities
+func (s *capabilityStore) InvokerForInvoke(invoker *CapabilityInvoker) mcps.Invoker {
+	const defaultBodyLimit = 20 * 1024 // 10KB
+
+	return func(ctx context.Context, args map[string]any) (map[string]any, error) {
+		method, _ := args["method"].(string)
+		if method == "" {
+			return mcps.BuildToolErrorResult("missing required argument: method"), nil
+		}
+
+		endpoint, _ := args["endpoint"].(string)
+		if endpoint == "" {
+			return mcps.BuildToolErrorResult("missing required argument: endpoint"), nil
+		}
+
+		params, _ := args["params"].(map[string]any)
+		if params == nil {
+			params = make(map[string]any)
+		}
+
+		resp, err := invoker.Invoke(ctx, method, endpoint, params)
+		if err != nil {
+			logger().Infow("invoke fail", "err", err)
+			return mcps.BuildToolErrorResult(err.Error()), nil
+		}
+		if resp == nil {
+			return mcps.BuildToolErrorResult("nil response from invoker"), nil
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode == 403 {
+			return mcps.BuildToolErrorResult("Permission denied: no access to this API"), nil
+		}
+
+		// Limit body to 10KB by default, allow override via args
+		limit := defaultBodyLimit
+		if l, ok := args["limit"].(float64); ok {
+			limit = int(l)
+		}
+		limitedReader := io.LimitReader(resp.Body, int64(limit))
+		body, err := io.ReadAll(limitedReader)
+		if err != nil {
+			return mcps.BuildToolErrorResult(err.Error()), nil
+		}
+
+		if settings.InDevelop() {
+			fmt.Fprintf(os.Stderr, "\n%s\n", (body))
+		}
+
+		// Check if response was truncated by reading 1 more byte
+		truncated := false
+		if b := make([]byte, 1); len(body) == limit {
+			if n, _ := resp.Body.Read(b); n > 0 {
+				truncated = true
+			}
+		}
+
+		logger().Infow("invoked", "sc", resp.StatusCode, "cl", len(body),
+			"truncated", truncated, "tail", words.TakeTail(string(body), 20))
+
+		result := map[string]any{"body": string(body)}
+		if truncated {
+			result["truncated"] = true
+			result["limit"] = limit
+		}
+		return mcps.BuildToolSuccessResult(result), nil
+	}
+}

--- a/pkg/services/stores/interfaces.go
+++ b/pkg/services/stores/interfaces.go
@@ -10,4 +10,5 @@ type Storage interface {
 	MCP() MCPStore      // gened
 	Convo() ConvoStore  // gened
 	State() StateStore
+	Capability() CapabilityStore // gened
 }

--- a/pkg/services/stores/wrap.go
+++ b/pkg/services/stores/wrap.go
@@ -102,9 +102,10 @@ type Wrap struct {
 	preset     aigc.Preset
 	stateStore *stateStore
 
-	corpuStore *corpuStore // gened
-	mcpStore   *mcpStore   // gened
-	convoStore *convoStore // gened
+	corpuStore      *corpuStore      // gened
+	mcpStore        *mcpStore        // gened
+	convoStore      *convoStore      // gened
+	capabilityStore *capabilityStore // gened
 }
 
 // NewWithDB return new instance of Wrap
@@ -116,9 +117,10 @@ func NewWithDB(db *pgx.DB) *Wrap {
 
 	w.stateStore = &stateStore{rc: SgtRC()}
 
-	w.corpuStore = &corpuStore{w: w} // gened
-	w.mcpStore = &mcpStore{w: w}     // gened
-	w.convoStore = &convoStore{w: w} // gened
+	w.corpuStore = &corpuStore{w: w}           // gened
+	w.mcpStore = &mcpStore{w: w}               // gened
+	w.convoStore = &convoStore{w: w}           // gened
+	w.capabilityStore = &capabilityStore{w: w} // gened
 
 	// more member stores
 	return w
@@ -178,8 +180,9 @@ func InitDB(ctx context.Context) error {
 
 func (w *Wrap) Preset() aigc.Preset { return w.preset }
 
-func (w *Wrap) Corpus() CorpuStore { return w.corpuStore } // Corpu gened
-func (w *Wrap) KB() CorpuStore     { return w.corpuStore } // Corpu alias
-func (w *Wrap) MCP() MCPStore      { return w.mcpStore }   // MCP gened
-func (w *Wrap) Convo() ConvoStore  { return w.convoStore } // Convo gened
-func (w *Wrap) State() StateStore  { return w.stateStore }
+func (w *Wrap) Corpus() CorpuStore          { return w.corpuStore } // Corpu gened
+func (w *Wrap) KB() CorpuStore              { return w.corpuStore } // Corpu alias
+func (w *Wrap) MCP() MCPStore               { return w.mcpStore }   // MCP gened
+func (w *Wrap) Convo() ConvoStore           { return w.convoStore } // Convo gened
+func (w *Wrap) State() StateStore           { return w.stateStore }
+func (w *Wrap) Capability() CapabilityStore { return w.capabilityStore } // Capability gened

--- a/pkg/services/tools/defines.go
+++ b/pkg/services/tools/defines.go
@@ -18,6 +18,9 @@ const (
 	ToolNameMemoryStore  = "memory_store"  // 记忆存储工具
 	ToolNameMemoryForget = "memory_forget" // 记忆删除工具
 
+	ToolNameCapabilityMatch  = "capability_match"  // API 能力匹配工具
+	ToolNameCapabilityInvoke = "capability_invoke" // API 能力调用工具
+
 	ToolNameStrataExec = "strata_exec"
 )
 
@@ -189,6 +192,60 @@ var (
 				},
 			},
 			"required": []string{"key"},
+		},
+	}
+
+	// capabilityMatchDescriptor API 能力匹配工具描述
+	capabilityMatchDescriptor = mcps.ToolDescriptor{
+		Name:        ToolNameCapabilityMatch,
+		Description: "Match API capabilities by user intent. Most APIs are RESTful, so each intent should target a single resource for best matching. Returns 3-5 relevant APIs based on semantic similarity.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"intent": map[string]any{
+					"type":        "string",
+					"description": "User's intent targeting a single resource (e.g., '查询我的订单', '创建文章')",
+				},
+				"limit": map[string]any{
+					"type":        "integer",
+					"description": "Max results to return (default: 5)",
+					"default":     5,
+					"minimum":     1,
+					"maximum":     10,
+				},
+			},
+			"required": []string{"intent"},
+		},
+	}
+
+	// capabilityInvokeDescriptor API 能力调用工具描述
+	capabilityInvokeDescriptor = mcps.ToolDescriptor{
+		Name:        ToolNameCapabilityInvoke,
+		Description: "Invoke a specific API capability. Returns the API response from Bus. Use the capability info from capability_match to construct the request. The method, endpoint are provided for LLM to construct the full URI. Note: Database fields use snake_case naming, not camelCase. For example, joiningAt in the model is joining_at in the database. This is especially useful when sorting.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"method": map[string]any{
+					"type":        "string",
+					"description": "HTTP method (GET, POST, PUT, DELETE, etc.)",
+				},
+				"endpoint": map[string]any{
+					"type":        "string",
+					"description": "API endpoint path (may contain path variables like /api/accounts/{id})",
+				},
+				"params": map[string]any{
+					"type":        "object",
+					"description": "API parameters values to fill in (path variables, query params, body, etc.)",
+				},
+				"limit": map[string]any{
+					"type":        "number",
+					"description": "Max bytes of response body to return (default: 204800, max: 204800)",
+					"default":     204800,
+					"minimum":     0,
+					"maximum":     204800,
+				},
+			},
+			"required": []string{"method", "endpoint"},
 		},
 	}
 

--- a/pkg/services/tools/registry.go
+++ b/pkg/services/tools/registry.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/liut/morign/pkg/models/mcps"
 	"github.com/liut/morign/pkg/services/stores"
+	"github.com/liut/morign/pkg/settings"
 )
 
 type Invoker = mcps.Invoker
@@ -124,6 +125,14 @@ func (r *Registry) initTools(sto stores.Storage) {
 		r.invokers[ToolNameMemoryRecall] = sto.Convo().InvokerForMemoryRecall()
 		r.invokers[ToolNameMemoryStore] = sto.Convo().InvokerForMemoryStore()
 		r.invokers[ToolNameMemoryForget] = sto.Convo().InvokerForMemoryForget()
+
+		// Capability tools - type assert to get X interface
+		ctx := context.Background()
+		if count, err := sto.Capability().CountCapability(ctx); err == nil && count > 10 {
+			r.tools = append(r.tools, capabilityMatchDescriptor, capabilityInvokeDescriptor)
+			r.invokers[ToolNameCapabilityMatch] = sto.Capability().InvokerForMatch()
+			r.invokers[ToolNameCapabilityInvoke] = sto.Capability().InvokerForInvoke(stores.NewCapabilityInvoker(settings.Current.BusAPIURL))
+		}
 	}
 
 	// 公开工具：Fetch

--- a/pkg/settings/config.go
+++ b/pkg/settings/config.go
@@ -36,6 +36,9 @@ type Config struct {
 	OAuthName    string `envconfig:"OAuth_Name" default:"oauth" desc:"Name of OAuth SP"`
 	OAuthPathMCP string `envconfig:"OAuth_Path_MCP" desc:"OAuth SP as A MCP Server"`
 
+	// BusAPIURL is the base URL for Bus API calls (used by capability invoke)
+	BusAPIURL string `envconfig:"Bus_API_URL" desc:"Base URL for Bus API"`
+
 	SitePathMe   string `envconfig:"Site_Path_Me" desc:"OAuth SP Path of /api/me in whole site"`
 	SiteTokenKey string `envconfig:"Site_Token_Key" default:"token" desc:"token key in whole site"`
 
@@ -57,10 +60,10 @@ type Config struct {
 	// 相似度阈值 建议范围 0.39 - 0.65, 数值越大条件越宽
 	VectorThreshold float32 `envconfig:"Vector_Threshold" default:"0.47"`
 	// 相似度匹配数量
-	VectorLimit int `envconfig:"Vector_Limit" default:"5"`
+	VectorLimit int `envconfig:"Vector_Limit" default:"6"`
 
 	// LLM调用循环次数限制，防止无限循环
-	MaxLoopIterations int `envconfig:"MAX_LOOP_ITERATIONS" default:"5"`
+	MaxLoopIterations int `envconfig:"MAX_LOOP_ITERATIONS" default:"12"`
 
 	Embedding Provider
 	Interact  Provider

--- a/pkg/web/api/api.go
+++ b/pkg/web/api/api.go
@@ -71,6 +71,10 @@ func strap(r chi.Router) {
 func newapi(sto stores.Storage) *api {
 	preset, _ := stores.LoadPreset()
 
+	if len(settings.Current.BusAPIURL) == 0 {
+		settings.Current.BusAPIURL = staffio.GetPrefix()
+	}
+
 	// 初始化 OAuth MCP 配置
 	var opts = []tools.RegistryOption{
 		tools.WithClientInfo(settings.Current.Name, settings.Version()),


### PR DESCRIPTION
- Add CapabilityStoreX interface with ImportCapabilities, MatchCapabilities, SyncEmbeddingCapabilities
- Add pgvector stored procedure vector_match_capability_4 for similarity search
- Support both JSON and YAML swagger format in ImportCapabilities
- Add capability_match and capability_invoke MCP tools for agent API discovery and invocation
- Add response body limit (default 10KB) with truncation detection for capability_invoke
- Fix type assertion safety (CapabilityStore embeds CapabilityStoreX)