### PR TITLE
feat(tools): add channel-scoped MCP server registration

### DIFF
--- a/docs/mcps.yaml
+++ b/docs/mcps.yaml
@@ -117,6 +117,11 @@ models:
         type: HeaderFunc
         tags: {bson: '-', json: '-', pg: '-'}
         basic: true
+      - comment: 频道名，非空时该 server 为频道专属
+        name: Channel
+        type: string
+        tags: {bson: '-', json: 'channel,omitempty', pg: '-'}
+        basic: true
 
       - type: comm.MetaField
     oidcat: file

--- a/docs/plans/2026-06-02-001-feat-channel-mcp-tools-plan.md
+++ b/docs/plans/2026-06-02-001-feat-channel-mcp-tools-plan.md
@@ -1,0 +1,251 @@
+---
+type: feat
+origin: docs/brainstorms/2026-06-02-channel-mcp-tools-requirements.md
+status: active
+---
+
+# feat: 频道专属 MCP 工具注册
+
+## Summary
+
+为每个频道（WeCom、Feishu）支持声明专属的 MCP Server 列表，Registry 按当前频道上下文返回「全局工具 + 该频道专属工具」，实现频道级工具可见性隔离。
+
+---
+
+## Problem Frame
+
+当前 MCP Server 工具全局可见——WeCom 频道专属的 API 封装工具会出现在飞书频道的工具列表中，造成工具集膨胀。需要频道级作用域机制。详见 origin doc Problem Frame。
+
+---
+
+## Requirements Trace
+
+| Origin | Requirement |
+|--------|-------------|
+| R1 | Preset ChannelConfig 支持 `mcp_servers` 字段 |
+| R2 | 工具名 `{channel}_{server_name}-{tool_name}` 格式 |
+| R3, R4 | `ToolsFor(ctx)` 按 context 中频道名返回全局+频道工具；无频道时仅全局 |
+| R5 | 频道工具始终公开，不受 keeper 限制 |
+| R6, R7, R8 | 频道启动时注册 MCP 工具，停止时清理，连接失败降级 |
+| R9, R10 | 全局重名冲突检测；同频道内 server 间重名检测 |
+| R11 | 频道 MCP 健康可查询 |
+| R12 | 设计决策包含 capability 对比 |
+
+---
+
+## Key Technical Decisions
+
+1. **频道作用域 key 使用频道类型名（`p.Name()`，如 `"wecom"`）而非实例 key（`"wecom-websocket"`）。** 同类型多实例共享 MCP 工具——session key 的频道段也是类型名，保持一致。
+2. **频道工具存储为独立 `channelTools map[string]*channelToolSet`**，而非打散到全局列表中再加 tag 过滤。物理隔离避免全局列表膨胀和过滤开销。
+3. **频道名通过 context 传递**，遵循现有 `ContextWithServerName` 模式，在 `MessageHandler` 中注入。
+4. **MCP 连接失败降级不阻塞频道启动**，记 warning 继续。与现有 `LoadServers` 的容错行为一致。
+5. **Preset 配置结构新增 `MCPServerConfig`**，只含 preset 需要的字段（Name、URL、TransType、HeaderCate），不复用 DB 模型 `mcps.Server`。
+
+---
+
+## Implementation Units
+
+### U1. 修复 Registry 现有竞态条件
+
+**Goal:** 修复 `AddServer` 中 check-then-register 的锁覆盖范围和 `ToolsFor` 的读锁缺失，为后续频道作用域改造提供安全基础。
+
+**Requirements:** (prerequisite, no origin R-ID)
+
+**Dependencies:** none
+
+**Files:**
+- `pkg/services/tools/registry.go`
+
+**Approach:**
+- `AddServer`：将 `serversMu.Lock()` 提前到冲突检测之前，使 check + register 在同一临界区内
+- `checkToolNameConflict`：调用方已持锁，移除其内部的 `RLock`（当前函数在 `AddServer` 内被调用时无锁，在 `AddInvoker` 内被调用时也无锁——统一由调用方持锁）
+- `ToolsFor`：读取 `r.tools` 和 `r.privTools` 时加 `serversMu.RLock`
+- `callServerTool`：将 server 查找和 `CallTool` 放在同一 `RLock` 临界区内，消除 TOCTOU
+
+**Patterns to follow:** 现有 `serversMu` 用法风格
+
+**Test scenarios:**
+- 并发 `AddServer` 不产生重名工具（go test -race）
+- `ToolsFor` 与 `AddServer` 并发执行不触发 race detector
+- `callServerTool` 在 server 被并发 Remove 后返回 "server not found" 而非 panic
+
+**Verification:** `go test -race ./pkg/services/tools/` 通过
+
+---
+
+### U2. 频道 Context 传递
+
+**Goal:** 新增 context key 和 helper 函数，使频道名可从 context 提取；在 `MessageHandler` 中注入频道名。
+
+**Requirements:** R3, R4
+
+**Dependencies:** U1
+
+**Files:**
+- `pkg/models/mcps/mcps_x.go`
+- `pkg/web/api/handle_platform.go`
+
+**Approach:**
+- 在 `mcps_x.go` 新增 `ctxChannelKey`（空 struct）、`ContextWithChannel(ctx, name)`、`ChannelFromContext(ctx)`
+- 在 `MessageHandler` 中，用户/OAuth 注入之后（handle_platform.go:117 行附近），调用 `ctx = mcps.ContextWithChannel(ctx, p.Name())`
+- `prepareSystemMessage` 现有签名不感知频道——ctx 已携带频道信息，无需改签名
+
+**Patterns to follow:** `ContextWithServerName` / `ServerNameFromContext`（mcps_x.go:24-35），`ContextWithUser`（stores/auth.go:38）
+
+**Test scenarios:**
+- `MessageHandler` 调用后 ctx 中可提取 `p.Name()` 值
+- HTTP API 路径（无频道上下文）调用 `ToolsFor` 时 `ChannelFromContext` 返回空字符串
+- `ChannelFromContext` 在未注入频道名的 context 上返回 ""
+
+**Verification:** 现有频道消息处理测试通过；手动验证 HTTP API 路径不回归
+
+---
+
+### U3. Preset ChannelConfig 扩展
+
+**Goal:** 在 `ChannelConfig` 中新增 `MCPServers` 字段，定义 preset 可声明的 MCP Server 配置结构。
+
+**Requirements:** R1
+
+**Dependencies:** none
+
+**Files:**
+- `pkg/models/aigc/preset.go`
+
+**Approach:**
+- 新增 `MCPServerConfig` 结构体：`Name`、`URL`、`TransType`（`mcps.TransType`）、`HeaderCate`（`mcps.HeaderCate`）
+- 在 `ChannelConfig` 中新增 `MCPServers []MCPServerConfig` 字段，YAML tag `mcp_servers`
+- 不复用 `mcps.Server`——preset 不需要 ORM 字段（BaseModel、DefaultModel、MetaField）和运行时字段（HeaderFunc、Status）
+
+**Patterns to follow:** `ChannelConfig` 现有结构风格
+
+**Test scenarios:**
+- YAML 解析 `mcp_servers` 列表正确填充 `MCPServers` 字段
+- 未配置 `mcp_servers` 时字段为 nil（向后兼容）
+- `TransType` 枚举值正确序列化/反序列化
+
+**Verification:** preset 解析单元测试；现有 preset YAML 加载不报错
+
+---
+
+### U4. Registry 频道作用域改造
+
+**Goal:** Registry 支持按频道存储和检索工具；`ToolsFor` 和 `Invoke` 感知频道上下文。
+
+**Requirements:** R2, R3, R4, R5
+
+**Dependencies:** U1, U2
+
+**Files:**
+- `pkg/services/tools/registry.go`
+- `pkg/services/tools/connection.go`
+
+**Approach:**
+- 新增 `channelToolSet` 结构体，包含 `tools []mcps.ToolDescriptor`、`invokers map[string]Invoker`、`servers map[string]*MCPConnection`、`mu sync.RWMutex`
+- Registry 新增 `channelTools map[string]*channelToolSet` 字段（key = 频道名）+ `channelMu sync.RWMutex`
+- `ToolsFor(ctx)` 从 ctx 提取频道名，若存在则合并 `channelTools[name].tools` + 全局 `r.tools`；无频道名时仅返回全局工具。频道工具不涉及 `privTools`（R5: 始终公开）
+- `Invoke(ctx, name, params)` 先从 ctx 提取频道名，若存在则先查频道 invokers，未命中再查全局 invokers
+- 新增 `AddChannelServer(ctx, channel string, cfg MCPServerConfig)` 方法：创建 transport → 连接 MCP → 列举工具 → 注册到对应 `channelToolSet`
+- 工具名格式：`getToolKey` 改为 `{channel}_{serverName}-{toolName}`（R2），修改 `connection.go`
+- 新增 `RemoveChannelServer(channel, serverName string)` 方法
+- 新增 `RemoveChannelTools(channel string)` 方法（频道停止时批量清理）
+
+**Patterns to follow:** 现有 `AddServer`、`RemoveServer`、`ToolsFor` 逻辑
+
+**Test scenarios:**
+- `ToolsFor(ctx)` with channel context 返回全局+频道工具
+- `ToolsFor(ctx)` without channel context 仅返回全局工具
+- `Invoke` 正确路由频道专属工具调用
+- 频道工具名冲突（同频道内）返回 error
+- 不同频道同名 server 不冲突（不同 `channelToolSet`）
+- 频道工具不受 keeper 角色影响——`IsKeeper` 为 false 时仍可见
+
+**Verification:** `go test -race ./pkg/services/tools/` 通过；手动集成测试 WeCom 频道调用专属工具
+
+---
+
+### U5. 频道生命周期集成
+
+**Goal:** 在 `InitChannels` 中为每个频道初始化其 MCP Server；在 `StopChannels` 中清理。
+
+**Requirements:** R6, R7, R8
+
+**Dependencies:** U3, U4
+
+**Files:**
+- `pkg/web/api/handle_platform.go`
+
+**Approach:**
+- `InitChannels` 中，频道 `Start` 成功后，遍历 `cfg.MCPServers`，对每个 server 调用 `toolreg.AddChannelServer(ctx, name, server)`（name = `p.Name()`）
+- 若 `AddChannelServer` 失败，记 `logger().Warnw("channel MCP server init failed", ...)`，继续处理下一个 server（R8 降级）
+- `StopChannels` 中，`StopAll` 之前，遍历 tracked channels，对每个调用 `toolreg.RemoveChannelTools(name)`
+- 频道 MCP 生命周期与频道实例生命周期绑定——不跟随 WebSocket 重连重建（MCP 连接独立于 WS 连接）
+
+**Patterns to follow:** 现有 `InitChannels` 循环结构、`LoadServers` 容错风格
+
+**Test scenarios:**
+- 配置 2 个 MCP Server，1 个 URL 不可达——频道正常启动，可达 server 的工具已注册，不可达的记 warning
+- `StopChannels` 后频道工具从 `ToolsFor` 中消失
+- 频道重启后 MCP 工具重新注册（无 "already exists" 错误）
+
+**Verification:** 集成测试——启动带 MCP 配置的频道，验证工具可见性；停止频道，验证工具移除
+
+---
+
+### U6. 健康查询
+
+**Goal:** 提供频道 MCP 工具状态查询能力。
+
+**Requirements:** R11
+
+**Dependencies:** U4
+
+**Files:**
+- `pkg/services/tools/registry.go`
+- `pkg/web/api/handle_platform.go`（或新 handler 文件）
+
+**Approach:**
+- Registry 新增 `ChannelServerStatus(channel string) []ServerStatus` 方法，返回每个 server 的连接状态和已注册工具列表
+- 在 HTTP router 上注册 `/health/channel/{name}/tools` 端点（或复用现有 health 端点扩展）
+- 返回 JSON：server name、URL、连接状态、工具数、工具名列表
+
+**Patterns to follow:** 现有 API handler 风格
+
+**Test scenarios:**
+- 健康端点返回频道 MCP 连接状态
+- MCP 不可达时状态反映为 disconnected 及错误信息
+- 无 MCP 配置的频道返回空列表
+
+**Verification:** HTTP 请求 `/health/channel/wecom/tools` 返回正确状态
+
+---
+
+## Scope Boundaries
+
+- 不支持运行时动态增删频道 MCP（preset 配置，重启生效）
+- 不支持跨频道 MCP 连接池复用——每个频道独立维护连接
+- 不支持 MCP 连接自动重连——连接失败后需重启恢复
+
+### Deferred to Follow-Up Work
+
+- MCP 连接健康检查和自动重连机制
+- Preset 热加载（SIGHUP 或 admin API）
+- 跨频道共享 MCP 连接的连接池
+
+---
+
+## Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| MCP Server 启动枚举时响应慢，阻塞频道初始化 | 频道启动变慢 | `AddChannelServer` 加超时 context（30s）；失败降级不阻塞 |
+| 频道工具数量增长导致 LLM function-calling 精度下降 | 工具选择错误率上升 | 当前规模可控；后续可加工具数上限 |
+| `Invoke` 需要同时查频道和全局 invoker map，性能影响 | 轻微延迟 | 两级 map 查找，O(1)；频道工具量小（通常 <20） |
+
+---
+
+## Review Notes
+
+### From 2026-06-02 review (resolved by U4)
+
+- **Invoke must be channel-aware for ToolsFor to be useful** — U4 resolves this by making Invoke search channel-scoped invokers first.

--- a/pkg/models/aigc/preset.go
+++ b/pkg/models/aigc/preset.go
@@ -1,5 +1,15 @@
 package aigc
 
+import "github.com/liut/morign/pkg/models/mcps"
+
+// MCPServerConfig 定义 preset 中频道专属 MCP Server 的配置结构
+type MCPServerConfig struct {
+	Name       string          `json:"name" yaml:"name"`
+	URL        string          `json:"url" yaml:"url"`
+	TransType  mcps.TransType  `json:"trans_type" yaml:"trans_type"`
+	HeaderCate mcps.HeaderCate `json:"header_cate,omitempty" yaml:"header_cate,omitempty"`
+}
+
 // Preset is the preset configuration including welcome message, system prompt and tool descriptions
 type Preset struct {
 	Welcome       string `json:"welcome,omitempty" yaml:"welcome,omitempty"`
@@ -19,7 +29,8 @@ type Preset struct {
 
 // ChannelConfig holds configuration for a single channel adapter.
 type ChannelConfig struct {
-	Enable bool              `json:"enable,omitempty" yaml:"enable,omitempty"`
-	Mode   string            `json:"mode,omitempty" yaml:"mode,omitempty"` // "websocket", "webhook"
-	Config map[string]any    `json:"config,omitempty" yaml:"config,omitempty"`
+	Enable     bool               `json:"enable,omitempty" yaml:"enable,omitempty"`
+	Mode       string             `json:"mode,omitempty" yaml:"mode,omitempty"` // "websocket", "webhook"
+	Config     map[string]any     `json:"config,omitempty" yaml:"config,omitempty"`
+	MCPServers []MCPServerConfig  `json:"mcpServers,omitempty" yaml:"mcpServers,omitempty"`
 }

--- a/pkg/models/mcps/mcps_gen.go
+++ b/pkg/models/mcps/mcps_gen.go
@@ -191,6 +191,8 @@ type ServerBasic struct {
 	HeaderCate HeaderCate `bson:"headerCate" bun:",notnull,type:smallint" enums:"authorization,ownerID,sessionID" extensions:"x-order=H" json:"headerCate" pg:",notnull,type:smallint" swaggertype:"string"`
 	// 定制头函数
 	HeaderFunc HeaderFunc `bson:"-" bun:"-" extensions:"x-order=I" json:"-" pg:"-"`
+	// 频道名，非空时该 server 为频道专属
+	Channel string `bson:"-" bun:"-" extensions:"x-order=J" form:"channel" json:"channel,omitempty" pg:"-"`
 	// for meta update
 	MetaDiff *comm.MetaDiff `bson:"-" bun:"-" json:"metaUp,omitempty" pg:"-" swaggerignore:"true"`
 } // @name mcpsServerBasic

--- a/pkg/models/mcps/mcps_x.go
+++ b/pkg/models/mcps/mcps_x.go
@@ -33,3 +33,16 @@ func ServerNameFromContext(ctx context.Context) string {
 	}
 	return ""
 }
+
+type ctxChannelKey struct{}
+
+func ContextWithChannel(ctx context.Context, name string) context.Context {
+	return context.WithValue(ctx, ctxChannelKey{}, name)
+}
+
+func ChannelFromContext(ctx context.Context) string {
+	if s, ok := ctx.Value(ctxChannelKey{}).(string); ok {
+		return s
+	}
+	return ""
+}

--- a/pkg/services/channels/registry.go
+++ b/pkg/services/channels/registry.go
@@ -20,14 +20,16 @@ type Factory func(opts map[string]any) (channel.Channel, error)
 
 // Registry manages channel adapters.
 type Registry struct {
-	channels map[string]Factory
-	started  map[string]channel.Channel
-	mu       sync.Mutex
+	channels   map[string]Factory
+	started    map[string]channel.Channel
+	onStop     map[string]func() // channel stop callbacks
+	mu         sync.Mutex
 }
 
 var registry = &Registry{
 	channels: make(map[string]Factory),
 	started:  make(map[string]channel.Channel),
+	onStop:   make(map[string]func()),
 }
 
 // RegisterChannel registers a channel factory under the given name.
@@ -52,17 +54,28 @@ func NewChannel(name string, opts map[string]any) (channel.Channel, error) {
 	return factory(opts)
 }
 
-// TrackChannel adds a started channel to the registry with a unique key.
-func TrackChannel(key string, p channel.Channel) {
+// TrackChannel adds a started channel to the registry. Optional onStop callback runs before StopAll.
+func TrackChannel(key string, p channel.Channel, onStop ...func()) {
 	registry.mu.Lock()
 	defer registry.mu.Unlock()
 	registry.started[key] = p
+	if len(onStop) > 0 && onStop[0] != nil {
+		registry.onStop[key] = onStop[0]
+	}
 }
 
-// StopAll stops all tracked channels.
+// StopAll stops all tracked channels, calling onStop callbacks first.
 func StopAll() {
 	registry.mu.Lock()
 	defer registry.mu.Unlock()
+	// Call onStop callbacks first (channel MCP cleanup)
+	for key, fn := range registry.onStop {
+		func() {
+			defer func() { _ = recover() }()
+			fn()
+		}()
+		delete(registry.onStop, key)
+	}
 	for name, p := range registry.started {
 		if err := p.Stop(); err != nil {
 			slog.Warn("channel: stop failed", "name", name, "error", err)

--- a/pkg/services/tools/connection.go
+++ b/pkg/services/tools/connection.go
@@ -10,6 +10,7 @@ import (
 
 // MCPConnection represents a connection to an MCP server
 type MCPConnection struct {
+	Channel   string
 	Name      string
 	URL       string
 	TransType mcps.TransType
@@ -17,7 +18,18 @@ type MCPConnection struct {
 	toolNames []string // 注册的工具名列表
 }
 
-// getToolKey returns the tool key with server prefix
-func (mcpc *MCPConnection) getToolKey(name string) string {
-	return fmt.Sprintf("%s__%s", mcpc.Name, name)
+func newMCPConnectionFromServer(sb *mcps.ServerBasic) *MCPConnection {
+	return &MCPConnection{
+		Channel:   sb.Channel,
+		Name:      sb.Name,
+		URL:       sb.URL,
+		TransType: sb.TransType,
+	}
+}
+
+func genToolKey(sn, tn string, ch string) string {
+	if len(ch) > 0 {
+		return fmt.Sprintf("%s__%s__%s", ch, sn, tn)
+	}
+	return fmt.Sprintf("%s__%s", sn, tn)
 }

--- a/pkg/services/tools/registry.go
+++ b/pkg/services/tools/registry.go
@@ -19,6 +19,14 @@ import (
 type Invoker = mcps.Invoker
 type HeaderFunc = transport.HTTPHeaderFunc
 
+// channelToolSet 存储单个频道的专属工具集
+type channelToolSet struct {
+	tools    []mcps.ToolDescriptor
+	invokers map[string]Invoker
+	servers  map[string]*MCPConnection
+	mu       sync.RWMutex
+}
+
 type Registry struct {
 	tools    []mcps.ToolDescriptor
 	invokers map[string]Invoker
@@ -32,6 +40,12 @@ type Registry struct {
 	// MCP Servers 连接容器（name -> connection）
 	servers   map[string]*MCPConnection
 	serversMu sync.RWMutex
+
+	toolsMu sync.RWMutex // 保护 tools、privTools、invokers 的并发访问
+
+	// 频道专属工具集（channel name -> tool set）
+	channelTools map[string]*channelToolSet
+	channelMu    sync.RWMutex
 }
 
 // RegistryOption 用于配置 Registry 的可选参数
@@ -53,9 +67,10 @@ func WithHeaderFunc(hf HeaderFunc) RegistryOption {
 // NewRegistry 创建工具注册表
 func NewRegistry(sto stores.Storage, opts ...RegistryOption) *Registry {
 	r := &Registry{
-		tools:    make([]mcps.ToolDescriptor, 0),
-		invokers: make(map[string]Invoker),
-		servers:  make(map[string]*MCPConnection),
+		tools:        make([]mcps.ToolDescriptor, 0),
+		invokers:     make(map[string]Invoker),
+		servers:      make(map[string]*MCPConnection),
+		channelTools: make(map[string]*channelToolSet),
 	}
 	r.initTools(sto)
 
@@ -66,13 +81,34 @@ func NewRegistry(sto stores.Storage, opts ...RegistryOption) *Registry {
 	return r
 }
 
-// Invoke 调用指定名称的工具
+// Invoke 调用指定名称的工具，频道工具优先
 func (r *Registry) Invoke(ctx context.Context, name string, params map[string]any) (map[string]any, error) {
 	if name == "" {
 		return mcps.BuildToolErrorResult("tool name is empty"), nil
 	}
 
 	logger().Debugw("invoking", "toolName", name, "params", params)
+
+	// 先查频道专属 invokers
+	if ch := mcps.ChannelFromContext(ctx); ch != "" {
+		r.channelMu.RLock()
+		cs := r.channelTools[ch]
+		r.channelMu.RUnlock()
+		if cs != nil {
+			cs.mu.RLock()
+			for key, invoker := range cs.invokers {
+				if strings.EqualFold(key, name) {
+					cs.mu.RUnlock()
+					return invoker(ctx, params)
+				}
+			}
+			cs.mu.RUnlock()
+		}
+	}
+
+	// 再查全局 invokers
+	r.toolsMu.RLock()
+	defer r.toolsMu.RUnlock()
 	for key, invoker := range r.invokers {
 		if strings.EqualFold(key, name) {
 			return invoker(ctx, params)
@@ -124,6 +160,9 @@ func (r *Registry) ApplyToolDescriptions(descriptions map[string]string) {
 		return
 	}
 
+	r.toolsMu.Lock()
+	defer r.toolsMu.Unlock()
+
 	// 更新内置工具描述
 	for i := range r.tools {
 		if desc, ok := descriptions[r.tools[i].Name]; ok && len(desc) > len(r.tools[i].Name) {
@@ -141,14 +180,30 @@ func (r *Registry) ApplyToolDescriptions(descriptions map[string]string) {
 
 // ToolsFor 返回适合当前上下文的工具列表
 // 如果用户有 keeper 角色，返回所有工具；否则只返回公开工具
+// 当 context 中有频道信息时，额外合并该频道的专属工具（始终公开）
 func (r *Registry) ToolsFor(ctx context.Context) []mcps.ToolDescriptor {
-	// TODO: 工具过滤器
+	r.toolsMu.RLock()
+	defer r.toolsMu.RUnlock()
 
+	base := make([]mcps.ToolDescriptor, len(r.tools))
+	copy(base, r.tools)
 	if stores.IsKeeper(ctx) {
-		// 合并公开工具和受限工具
-		return append(r.tools, r.privTools...)
+		base = append(base, r.privTools...)
 	}
-	return r.tools
+
+	// 合并频道专属工具（始终公开）
+	if ch := mcps.ChannelFromContext(ctx); ch != "" {
+		r.channelMu.RLock()
+		cs := r.channelTools[ch]
+		r.channelMu.RUnlock()
+		if cs != nil {
+			cs.mu.RLock()
+			base = append(base, cs.tools...)
+			cs.mu.RUnlock()
+		}
+	}
+
+	return base
 }
 
 // convertInputSchema 将 ToolInputSchema 转换为 map[string]any
@@ -191,22 +246,20 @@ func convertMCPToolResult(result *mcp.CallToolResult) map[string]any {
 	})
 }
 
-// AddServer 添加一个 MCP Server 并初始化连接
-// 仅支持远程传输类型（SSE 或 Streamable）
+// AddServer 添加 MCP Server 并初始化连接。server.Channel 非空时注册为频道专属工具。
 func (r *Registry) AddServer(ctx context.Context, server *mcps.ServerBasic) error {
-	// 验证传输类型
 	if !server.TransType.IsRemote() {
-		return fmt.Errorf("unsupported transport type: %v (only SSE and Streamable are supported)", server.TransType)
+		return fmt.Errorf("unsupported transport type: %v", server.TransType)
 	}
-
-	// 验证 URL
 	if server.URL == "" {
 		return fmt.Errorf("URL is required")
 	}
 
-	// 检查名称冲突
-	if err := r.checkToolNameConflict(server.Name); err != nil {
-		return err
+	// 全局 server 检查名称冲突（快速失败，网络 I/O 前）
+	if server.Channel == "" {
+		if err := r.checkServerNameConflict(server.Name); err != nil {
+			return err
+		}
 	}
 
 	hf := HeaderFunc(server.HeaderFunc)
@@ -214,16 +267,13 @@ func (r *Registry) AddServer(ctx context.Context, server *mcps.ServerBasic) erro
 		hf = r.headerFunc
 	}
 
-	// 创建 transport（使用接口类型）
 	var tp transport.Interface
 	var err error
 	switch server.TransType {
 	case mcps.TransTypeSSE:
-		tp, err = transport.NewSSE(server.URL,
-			transport.WithHeaderFunc(hf))
+		tp, err = transport.NewSSE(server.URL, transport.WithHeaderFunc(hf))
 	case mcps.TransTypeStreamable:
-		tp, err = transport.NewStreamableHTTP(server.URL,
-			transport.WithHTTPHeaderFunc(hf))
+		tp, err = transport.NewStreamableHTTP(server.URL, transport.WithHTTPHeaderFunc(hf))
 	default:
 		return fmt.Errorf("unsupported transport type: %v", server.TransType)
 	}
@@ -231,7 +281,6 @@ func (r *Registry) AddServer(ctx context.Context, server *mcps.ServerBasic) erro
 		return fmt.Errorf("failed to create transport: %w", err)
 	}
 
-	// 创建并启动 client
 	c := client.NewClient(tp)
 	if err := c.Start(ctx); err != nil {
 		return fmt.Errorf("failed to start MCP client: %w", err)
@@ -256,55 +305,117 @@ func (r *Registry) AddServer(ctx context.Context, server *mcps.ServerBasic) erro
 		return fmt.Errorf("failed to list tools: %w", err)
 	}
 
-	// 检查新工具名是否冲突
+	// 注册工具 —— 锁覆盖冲突检测 + 注册，不跨越网络 I/O
+	if server.Channel == "" {
+		r.toolsMu.Lock()
+		r.serversMu.Lock()
+		defer r.toolsMu.Unlock()
+		defer r.serversMu.Unlock()
+		return r.registerToolsLocked(&r.tools, r.invokers, r.servers, server, c, result)
+	}
+
+	r.channelMu.Lock()
+	cs := r.channelTools[server.Channel]
+	if cs == nil {
+		cs = &channelToolSet{
+			tools:    make([]mcps.ToolDescriptor, 0),
+			invokers: make(map[string]Invoker),
+			servers:  make(map[string]*MCPConnection),
+		}
+		r.channelTools[server.Channel] = cs
+	}
+	r.channelMu.Unlock()
+
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	r.toolsMu.RLock()
+	defer r.toolsMu.RUnlock()
+	return r.registerToolsLocked(&cs.tools, cs.invokers, cs.servers, server, c, result)
+}
+
+// registerToolsLocked 注册 MCP Server 工具到指定容器（调用方负责加锁）
+func (r *Registry) registerToolsLocked(
+	tools *[]mcps.ToolDescriptor, invokers map[string]Invoker, servers map[string]*MCPConnection,
+	server *mcps.ServerBasic, c *client.Client, result *mcp.ListToolsResult,
+) error {
+	// 校验工具名冲突（处理并发 AddServer 的 TOCTOU）
 	for _, tool := range result.Tools {
-		if err := r.checkToolNameConflict(tool.Name); err != nil {
+		toolKey := genToolKey(server.Name, tool.Name, server.Channel)
+		if err := r.checkToolNameConflict(toolKey); err != nil {
 			_ = c.Close()
 			return err
 		}
 	}
 
-	// 注册工具
-	r.serversMu.Lock()
-	mcpc := &MCPConnection{
-		Name:      server.Name,
-		URL:       server.URL,
-		TransType: server.TransType,
-		client:    c,
-	}
-	toolNames := make([]string, 0, len(result.Tools))
+	mcpc := newMCPConnectionFromServer(server)
+	mcpc.client = c
+	tNames := make([]string, 0, len(result.Tools))
 	for _, tool := range result.Tools {
-		toolKey := mcpc.getToolKey(tool.Name)
+		toolKey := genToolKey(server.Name, tool.Name, server.Channel)
 		inputSchema := convertInputSchema(tool.InputSchema)
-		r.tools = append(r.tools, mcps.ToolDescriptor{
-			Name:        toolKey,
-			Description: tool.Description,
-			InputSchema: inputSchema,
-		})
-		r.invokers[toolKey] = func(ctx context.Context, params map[string]any) (map[string]any, error) {
-			return r.callServerTool(ctx, server.Name, tool.Name, params)
+		*tools = append(*tools, mcps.ToolDescriptor{
+			Name: toolKey, Description: tool.Description, InputSchema: inputSchema})
+		client := c
+		invokers[toolKey] = func(ctx context.Context, params map[string]any) (map[string]any, error) {
+			return callServerToolWithClient(ctx, client, tool.Name, params)
 		}
-		toolNames = append(toolNames, toolKey)
-		logger().Infow("MCP tool registered", "server", server.Name, "tool", tool.Name)
+		tNames = append(tNames, toolKey)
+		logger().Infow("MCP tool registered", "toolKey", toolKey)
 	}
-	mcpc.toolNames = toolNames
-	r.servers[server.Name] = mcpc
-	r.serversMu.Unlock()
+	mcpc.toolNames = tNames
+	servers[server.Name] = mcpc
 
-	logger().Debugw("MCP server added", "name", server.Name, "url", server.URL, "tools", len(result.Tools))
+	logger().Debugw("MCP server added", "server", server.Name, "url", server.URL, "tools", len(result.Tools))
 	return nil
 }
 
-// checkToolNameConflict 检查工具名是否冲突
+// RemoveChannelTools 移除指定频道的所有专属工具
+func (r *Registry) RemoveChannelTools(channel string) {
+	r.channelMu.Lock()
+	cs := r.channelTools[channel]
+	if cs == nil {
+		r.channelMu.Unlock()
+		return
+	}
+	delete(r.channelTools, channel)
+	r.channelMu.Unlock()
+
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	for _, s := range cs.servers {
+		if s.client != nil {
+			_ = s.client.Close()
+		}
+	}
+	logger().Infow("channel MCP tools removed", "channel", channel)
+}
+
+// checkServerNameConflict 检查 server 名是否冲突（server 名独立于工具名）
+func (r *Registry) checkServerNameConflict(name string) error {
+	switch name {
+	case ToolNameKBSearch, ToolNameKBCreate, ToolNameFetch,
+		ToolNameMemoryList, ToolNameMemoryRecall, ToolNameMemoryStore, ToolNameMemoryForget:
+		return fmt.Errorf("server name %q conflicts with built-in tool", name)
+	}
+
+	r.serversMu.RLock()
+	defer r.serversMu.RUnlock()
+	for _, s := range r.servers {
+		if s.Name == name {
+			return fmt.Errorf("server %q already exists", name)
+		}
+	}
+	return nil
+}
+
+// checkToolNameConflict 检查工具名是否冲突（工具名独立于 server 名）
 func (r *Registry) checkToolNameConflict(name string) error {
-	// 检查是否与内置工具冲突
 	switch name {
 	case ToolNameKBSearch, ToolNameKBCreate, ToolNameFetch,
 		ToolNameMemoryList, ToolNameMemoryRecall, ToolNameMemoryStore, ToolNameMemoryForget:
 		return fmt.Errorf("tool name %q conflicts with built-in tool", name)
 	}
 
-	// 检查是否与已注册的工具冲突
 	for _, t := range r.tools {
 		if t.Name == name {
 			return fmt.Errorf("tool name %q already exists", name)
@@ -315,36 +426,45 @@ func (r *Registry) checkToolNameConflict(name string) error {
 			return fmt.Errorf("tool name %q already exists", name)
 		}
 	}
-
-	// 检查是否与已注册的 server 冲突
-	r.serversMu.RLock()
-	for _, s := range r.servers {
-		if s.Name == name {
-			r.serversMu.RUnlock()
-			return fmt.Errorf("server %q already exists", name)
-		}
-	}
-	r.serversMu.RUnlock()
-
 	return nil
 }
 
-// callServerTool 调用 MCP Server 工具
-func (r *Registry) callServerTool(ctx context.Context, serverName, toolName string, params map[string]any) (map[string]any, error) {
-	r.serversMu.RLock()
-	server, ok := r.servers[serverName]
-	r.serversMu.RUnlock()
+// ChannelServerStatus 表示频道 MCP Server 的状态
+type ChannelServerStatus struct {
+	Name  string   `json:"name"`
+	URL   string   `json:"url"`
+	Tools []string `json:"tools"`
+}
 
-	if !ok {
-		return mcps.BuildToolErrorResult("server not found"), nil
+// ChannelServerStatuses 返回指定频道的 MCP Server 状态列表
+func (r *Registry) ChannelServerStatuses(channel string) []ChannelServerStatus {
+	r.channelMu.RLock()
+	cs := r.channelTools[channel]
+	r.channelMu.RUnlock()
+	if cs == nil {
+		return nil
 	}
 
-	// 确保 params 不为空
+	cs.mu.RLock()
+	defer cs.mu.RUnlock()
+	result := make([]ChannelServerStatus, 0, len(cs.servers))
+	for _, s := range cs.servers {
+		result = append(result, ChannelServerStatus{
+			Name:  s.Name,
+			URL:   s.URL,
+			Tools: s.toolNames,
+		})
+	}
+	return result
+}
+
+// callServerToolWithClient 使用已捕获的 client 调用 MCP 工具，无需查 servers map
+func callServerToolWithClient(ctx context.Context, c *client.Client, toolName string, params map[string]any) (map[string]any, error) {
 	if params == nil {
 		params = make(map[string]any)
 	}
 
-	result, err := server.client.CallTool(mcps.ContextWithServerName(ctx, serverName),
+	result, err := c.CallTool(ctx,
 		mcp.CallToolRequest{
 			Params: mcp.CallToolParams{
 				Name:      toolName,
@@ -352,8 +472,8 @@ func (r *Registry) callServerTool(ctx context.Context, serverName, toolName stri
 			},
 		})
 	if err != nil {
-		logger().Errorw("MCP server tool call failed", "server", serverName, "tool", toolName, "err", err)
-		return mcps.BuildToolErrorResult(err.Error()), nil
+		logger().Errorw("MCP server tool call failed", "tool", toolName, "err", err)
+		return mcps.BuildToolErrorResult(fmt.Sprintf("tool '%s' call failed: %s", toolName, err)), nil
 	}
 
 	return convertMCPToolResult(result), nil
@@ -394,11 +514,13 @@ func (r *Registry) LoadServers(ctx context.Context, sto stores.Storage) error {
 
 // RemoveServer 移除 MCP Server 连接
 func (r *Registry) RemoveServer(name string) error {
+	r.toolsMu.Lock()
 	r.serversMu.Lock()
-	defer r.serversMu.Unlock()
 
 	conn, ok := r.servers[name]
 	if !ok {
+		r.serversMu.Unlock()
+		r.toolsMu.Unlock()
 		return fmt.Errorf("server %q not found", name)
 	}
 
@@ -421,6 +543,9 @@ func (r *Registry) RemoveServer(name string) error {
 	}
 	r.tools = newTools
 	delete(r.servers, name)
+	r.serversMu.Unlock()
+	r.toolsMu.Unlock()
+
 	logger().Infow("MCP server removed", "name", name)
 	return nil
 }

--- a/pkg/services/tools/zero_tools_test.go
+++ b/pkg/services/tools/zero_tools_test.go
@@ -1,0 +1,635 @@
+package tools
+
+import (
+	"context"
+	"testing"
+
+	mcp "github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/liut/morign/pkg/models/mcps"
+)
+
+// --- genToolKey ---
+
+func TestGenToolKey(t *testing.T) {
+	tests := []struct {
+		sn, tn, ch string
+		want       string
+	}{
+		{"srv", "tool", "", "srv__tool"},
+		{"srv", "tool", "wecom", "wecom__srv__tool"},
+		{"a", "b", "", "a__b"},
+		{"a", "b", "feishu", "feishu__a__b"},
+	}
+
+	for _, tt := range tests {
+		got := genToolKey(tt.sn, tt.tn, tt.ch)
+		if got != tt.want {
+			t.Errorf("genToolKey(%q, %q, %q) = %q, want %q", tt.sn, tt.tn, tt.ch, got, tt.want)
+		}
+	}
+}
+
+// --- newMCPConnectionFromServer ---
+
+func TestNewMCPConnectionFromServer(t *testing.T) {
+	sb := &mcps.ServerBasic{
+		Name:      "test-srv",
+		URL:       "http://localhost:8080/sse",
+		TransType: mcps.TransTypeSSE,
+		Channel:   "wecom",
+	}
+	mcpc := newMCPConnectionFromServer(sb)
+	if mcpc.Name != "test-srv" {
+		t.Errorf("Name = %q, want %q", mcpc.Name, "test-srv")
+	}
+	if mcpc.URL != "http://localhost:8080/sse" {
+		t.Errorf("URL = %q, want %q", mcpc.URL, "http://localhost:8080/sse")
+	}
+	if mcpc.Channel != "wecom" {
+		t.Errorf("Channel = %q, want %q", mcpc.Channel, "wecom")
+	}
+	if mcpc.client != nil {
+		t.Error("client should be nil")
+	}
+}
+
+// --- convertInputSchema ---
+
+func TestConvertInputSchema(t *testing.T) {
+	schema := mcp.ToolInputSchema{
+		Type: "object",
+		Properties: map[string]any{
+			"key": map[string]any{"type": "string"},
+		},
+		Required: []string{"key"},
+	}
+	result := convertInputSchema(schema)
+	if result["type"] != "object" {
+		t.Errorf("type = %v", result["type"])
+	}
+	props, ok := result["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("properties is not map[string]any")
+	}
+	if len(props) != 1 {
+		t.Errorf("properties len = %d, want 1", len(props))
+	}
+	req, ok := result["required"].([]string)
+	if !ok {
+		t.Fatal("required is not []string")
+	}
+	if len(req) != 1 || req[0] != "key" {
+		t.Errorf("required = %v", req)
+	}
+}
+
+func TestConvertInputSchemaNilFields(t *testing.T) {
+	schema := mcp.ToolInputSchema{Type: "object"}
+	result := convertInputSchema(schema)
+	if _, ok := result["properties"].(map[string]any); !ok {
+		t.Error("properties should be empty map when nil")
+	}
+	if _, ok := result["required"].([]string); !ok {
+		t.Error("required should be empty slice when nil")
+	}
+}
+
+// --- convertMCPToolResult ---
+
+func TestConvertMCPToolResult(t *testing.T) {
+	t.Run("empty content", func(t *testing.T) {
+		result := convertMCPToolResult(&mcp.CallToolResult{})
+		content, ok := result["content"].([]map[string]any)
+		if !ok || len(content) == 0 || content[0]["text"] != "ok" {
+			t.Errorf("empty content should return default ok, got %v", result)
+		}
+	})
+
+	t.Run("text success", func(t *testing.T) {
+		result := convertMCPToolResult(&mcp.CallToolResult{
+			Content: []mcp.Content{mcp.TextContent{Text: "hello"}},
+		})
+		sc, ok := result["structuredContent"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected structuredContent, got %v", result)
+		}
+		if sc["text"] != "hello" {
+			t.Errorf("text = %q", sc["text"])
+		}
+	})
+
+	t.Run("text error", func(t *testing.T) {
+		result := convertMCPToolResult(&mcp.CallToolResult{
+			IsError: true,
+			Content: []mcp.Content{mcp.TextContent{Text: "something went wrong"}},
+		})
+		if result["isError"] != true {
+			t.Error("should be error")
+		}
+		content, _ := result["content"].([]map[string]any)
+		if len(content) == 0 || content[0]["text"] != "something went wrong" {
+			t.Error("error content not preserved")
+		}
+	})
+
+	t.Run("non-text content", func(t *testing.T) {
+		result := convertMCPToolResult(&mcp.CallToolResult{
+			Content: []mcp.Content{mcp.EmbeddedResource{}},
+		})
+		sc, _ := result["structuredContent"].(map[string]any)
+		if _, ok := sc["content"]; !ok {
+			t.Error("should have content field for non-text type")
+		}
+	})
+}
+
+// --- Registry basics ---
+
+func newTestRegistry() *Registry {
+	return NewRegistry(nil)
+}
+
+func TestNewRegistry(t *testing.T) {
+	r := newTestRegistry()
+	if r == nil {
+		t.Fatal("NewRegistry returned nil")
+	}
+	if len(r.tools) == 0 {
+		t.Error("should have at least fetch tool")
+	}
+	if len(r.invokers) == 0 {
+		t.Error("should have at least fetch invoker")
+	}
+	if r.channelTools == nil {
+		t.Error("channelTools map should be initialized")
+	}
+}
+
+func TestWithClientInfo(t *testing.T) {
+	r := NewRegistry(nil, WithClientInfo("test-app", "1.0"))
+	if r.clientInfo.Name != "test-app" {
+		t.Errorf("clientInfo.Name = %q", r.clientInfo.Name)
+	}
+	if r.clientInfo.Version != "1.0" {
+		t.Errorf("clientInfo.Version = %q", r.clientInfo.Version)
+	}
+}
+
+// --- ToolsFor ---
+
+func TestToolsForReturnsPublicTools(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+	tools := r.ToolsFor(ctx)
+	if len(tools) == 0 {
+		t.Error("should have at least fetch tool for non-keeper")
+	}
+	found := false
+	for _, td := range tools {
+		if td.Name == ToolNameFetch {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("fetch tool not in public tools")
+	}
+}
+
+func TestToolsForWithChannel(t *testing.T) {
+	r := newTestRegistry()
+	chTool := mcps.ToolDescriptor{Name: "wecom__msg__send", Description: "send message"}
+	r.channelMu.Lock()
+	cs := &channelToolSet{
+		tools:    []mcps.ToolDescriptor{chTool},
+		invokers: make(map[string]Invoker),
+		servers:  make(map[string]*MCPConnection),
+	}
+	r.channelTools["wecom"] = cs
+	r.channelMu.Unlock()
+
+	ctx := mcps.ContextWithChannel(context.Background(), "wecom")
+	tools := r.ToolsFor(ctx)
+	found := false
+	for _, td := range tools {
+		if td.Name == "wecom__msg__send" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("channel tools should be included")
+	}
+}
+
+func TestToolsForWithoutChannel(t *testing.T) {
+	r := newTestRegistry()
+	chTool := mcps.ToolDescriptor{Name: "wecom__msg__send", Description: "send message"}
+	r.channelMu.Lock()
+	cs := &channelToolSet{
+		tools:    []mcps.ToolDescriptor{chTool},
+		invokers: make(map[string]Invoker),
+		servers:  make(map[string]*MCPConnection),
+	}
+	r.channelTools["wecom"] = cs
+	r.channelMu.Unlock()
+
+	ctx := context.Background()
+	tools := r.ToolsFor(ctx)
+	for _, td := range tools {
+		if td.Name == "wecom__msg__send" {
+			t.Error("channel tools should NOT be included without channel context")
+		}
+	}
+}
+
+// --- Invoke ---
+
+func TestInvokeEmptyName(t *testing.T) {
+	r := newTestRegistry()
+	result, err := r.Invoke(context.Background(), "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result["isError"] != true {
+		t.Error("empty name should return error result")
+	}
+}
+
+func TestInvokeNotFound(t *testing.T) {
+	r := newTestRegistry()
+	result, err := r.Invoke(context.Background(), "nonexistent_tool", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result["isError"] != true {
+		t.Error("unknown tool should return error result")
+	}
+}
+
+func TestInvokeChannelTool(t *testing.T) {
+	r := newTestRegistry()
+
+	called := false
+	invoker := func(ctx context.Context, params map[string]any) (map[string]any, error) {
+		called = true
+		return map[string]any{"content": []map[string]any{{"type": "text", "text": "ok"}}}, nil
+	}
+
+	r.channelMu.Lock()
+	cs := &channelToolSet{
+		tools:    []mcps.ToolDescriptor{{Name: "wecom__srv__hello"}},
+		invokers: map[string]Invoker{"wecom__srv__hello": invoker},
+		servers:  make(map[string]*MCPConnection),
+	}
+	r.channelTools["wecom"] = cs
+	r.channelMu.Unlock()
+
+	ctx := mcps.ContextWithChannel(context.Background(), "wecom")
+	result, err := r.Invoke(ctx, "wecom__srv__hello", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !called {
+		t.Error("channel invoker should have been called")
+	}
+	if result["isError"] == true {
+		t.Error("should be success")
+	}
+}
+
+func TestInvokeChannelToolNotFoundFallsBackToGlobal(t *testing.T) {
+	r := newTestRegistry()
+
+	r.channelMu.Lock()
+	cs := &channelToolSet{
+		tools:    []mcps.ToolDescriptor{{Name: "wecom__srv__other"}},
+		invokers: map[string]Invoker{},
+		servers:  make(map[string]*MCPConnection),
+	}
+	r.channelTools["wecom"] = cs
+	r.channelMu.Unlock()
+
+	ctx := mcps.ContextWithChannel(context.Background(), "wecom")
+	result, _ := r.Invoke(ctx, "wecom__srv__missing", nil)
+	if result["isError"] != true {
+		t.Error("should fall through to global and return error")
+	}
+}
+
+// --- ApplyToolDescriptions ---
+
+func TestApplyToolDescriptions(t *testing.T) {
+	r := newTestRegistry()
+	for i := range r.tools {
+		if r.tools[i].Name == ToolNameFetch {
+			r.tools[i].Description = "old"
+			break
+		}
+	}
+
+	desc := map[string]string{ToolNameFetch: "new longer description for fetch tool"}
+	r.ApplyToolDescriptions(desc)
+
+	for _, td := range r.tools {
+		if td.Name == ToolNameFetch && td.Description != "new longer description for fetch tool" {
+			t.Errorf("description not updated: %q", td.Description)
+		}
+	}
+}
+
+func TestApplyToolDescriptionsEmpty(t *testing.T) {
+	r := newTestRegistry()
+	r.ApplyToolDescriptions(nil)
+	r.ApplyToolDescriptions(map[string]string{})
+}
+
+func TestApplyToolDescriptionsTooShort(t *testing.T) {
+	r := newTestRegistry()
+	for i := range r.tools {
+		if r.tools[i].Name == ToolNameFetch {
+			r.tools[i].Description = "a long description"
+			break
+		}
+	}
+
+	desc := map[string]string{ToolNameFetch: "short"}
+	r.ApplyToolDescriptions(desc)
+
+	for _, td := range r.tools {
+		if td.Name == ToolNameFetch && td.Description != "a long description" {
+			t.Error("short description should not overwrite")
+		}
+	}
+}
+
+// --- checkServerNameConflict ---
+
+func TestCheckServerNameConflict(t *testing.T) {
+	r := newTestRegistry()
+
+	t.Run("built-in tool name", func(t *testing.T) {
+		err := r.checkServerNameConflict("kb_search")
+		if err == nil {
+			t.Error("kb_search as server name should conflict with built-in tool")
+		}
+	})
+
+	t.Run("ok name", func(t *testing.T) {
+		err := r.checkServerNameConflict("my-custom-server")
+		if err != nil {
+			t.Errorf("unexpected conflict: %v", err)
+		}
+	})
+
+	t.Run("duplicate server", func(t *testing.T) {
+		r.serversMu.Lock()
+		r.servers["existing"] = &MCPConnection{Name: "existing"}
+		r.serversMu.Unlock()
+
+		err := r.checkServerNameConflict("existing")
+		if err == nil {
+			t.Error("duplicate server name should conflict")
+		}
+	})
+}
+
+// --- checkToolNameConflict ---
+
+func TestCheckToolNameConflict(t *testing.T) {
+	r := newTestRegistry()
+
+	t.Run("built-in tool name", func(t *testing.T) {
+		err := r.checkToolNameConflict("kb_search")
+		if err == nil {
+			t.Error("kb_search should conflict with built-in tool")
+		}
+	})
+
+	t.Run("existing tool", func(t *testing.T) {
+		err := r.checkToolNameConflict(ToolNameFetch)
+		if err == nil {
+			t.Error("fetch should conflict with existing tool")
+		}
+	})
+
+	t.Run("priv tool", func(t *testing.T) {
+		r.toolsMu.Lock()
+		r.privTools = append(r.privTools, mcps.ToolDescriptor{Name: "secret_tool"})
+		r.toolsMu.Unlock()
+
+		err := r.checkToolNameConflict("secret_tool")
+		if err == nil {
+			t.Error("priv tool name should conflict")
+		}
+	})
+
+	t.Run("ok name", func(t *testing.T) {
+		err := r.checkToolNameConflict("brand_new_tool")
+		if err != nil {
+			t.Errorf("unexpected conflict: %v", err)
+		}
+	})
+}
+
+// --- RemoveServer ---
+
+func TestRemoveServer(t *testing.T) {
+	r := newTestRegistry()
+
+	r.serversMu.Lock()
+	r.servers["dummy"] = &MCPConnection{
+		Name:      "dummy",
+		toolNames: []string{"dummy__tool"},
+	}
+	r.serversMu.Unlock()
+	r.toolsMu.Lock()
+	r.tools = append(r.tools, mcps.ToolDescriptor{Name: "dummy__tool"})
+	r.invokers["dummy__tool"] = func(ctx context.Context, p map[string]any) (map[string]any, error) {
+		return nil, nil
+	}
+	r.toolsMu.Unlock()
+
+	err := r.RemoveServer("dummy")
+	if err != nil {
+		t.Fatalf("RemoveServer: %v", err)
+	}
+
+	r.serversMu.RLock()
+	_, ok := r.servers["dummy"]
+	r.serversMu.RUnlock()
+	if ok {
+		t.Error("server should be removed")
+	}
+
+	r.toolsMu.RLock()
+	_, ok = r.invokers["dummy__tool"]
+	for _, td := range r.tools {
+		if td.Name == "dummy__tool" {
+			ok = true
+		}
+	}
+	r.toolsMu.RUnlock()
+	if ok {
+		t.Error("tool should be removed")
+	}
+}
+
+func TestRemoveServerNotFound(t *testing.T) {
+	r := newTestRegistry()
+	err := r.RemoveServer("nonexistent")
+	if err == nil {
+		t.Error("should return error for unknown server")
+	}
+}
+
+// --- RemoveChannelTools ---
+
+func TestRemoveChannelTools(t *testing.T) {
+	r := newTestRegistry()
+
+	chTool := mcps.ToolDescriptor{Name: "wecom__srv__hello"}
+	r.channelMu.Lock()
+	r.channelTools["wecom"] = &channelToolSet{
+		tools:    []mcps.ToolDescriptor{chTool},
+		invokers: make(map[string]Invoker),
+		servers:  make(map[string]*MCPConnection),
+	}
+	r.channelMu.Unlock()
+
+	r.RemoveChannelTools("wecom")
+
+	r.channelMu.RLock()
+	cs := r.channelTools["wecom"]
+	r.channelMu.RUnlock()
+	if cs != nil {
+		t.Error("channel tools should be removed")
+	}
+}
+
+func TestRemoveChannelToolsNotExist(t *testing.T) {
+	r := newTestRegistry()
+	r.RemoveChannelTools("nonexistent")
+}
+
+// --- ChannelServerStatuses ---
+
+func TestChannelServerStatuses(t *testing.T) {
+	r := newTestRegistry()
+
+	r.channelMu.Lock()
+	r.channelTools["wecom"] = &channelToolSet{
+		tools:    make([]mcps.ToolDescriptor, 0),
+		invokers: make(map[string]Invoker),
+		servers: map[string]*MCPConnection{
+			"msg": {Name: "msg", URL: "http://msg/sse", toolNames: []string{"send", "recv"}},
+		},
+	}
+	r.channelMu.Unlock()
+
+	statuses := r.ChannelServerStatuses("wecom")
+	if len(statuses) != 1 {
+		t.Fatalf("len = %d, want 1", len(statuses))
+	}
+	if statuses[0].Name != "msg" {
+		t.Errorf("Name = %q", statuses[0].Name)
+	}
+	if len(statuses[0].Tools) != 2 {
+		t.Errorf("Tools len = %d", len(statuses[0].Tools))
+	}
+}
+
+func TestChannelServerStatusesNotExist(t *testing.T) {
+	r := newTestRegistry()
+	statuses := r.ChannelServerStatuses("nonexistent")
+	if statuses != nil {
+		t.Error("should return nil for unknown channel")
+	}
+}
+
+// --- AddServer validation ---
+
+func TestAddServerNonRemoteTransType(t *testing.T) {
+	r := newTestRegistry()
+	err := r.AddServer(context.Background(), &mcps.ServerBasic{
+		TransType: mcps.TransTypeStdIO,
+	})
+	if err == nil {
+		t.Error("StdIO trans type should be rejected")
+	}
+}
+
+func TestAddServerEmptyURL(t *testing.T) {
+	r := newTestRegistry()
+	err := r.AddServer(context.Background(), &mcps.ServerBasic{
+		TransType: mcps.TransTypeSSE,
+	})
+	if err == nil {
+		t.Error("empty URL should be rejected")
+	}
+}
+
+// --- ResultLogs ---
+
+func TestResultLogsString(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		var rl ResultLogs
+		if rl.String() != "" {
+			t.Errorf("nil should return empty string, got %q", rl.String())
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		rl := ResultLogs{}
+		if rl.String() != "{}" {
+			t.Errorf("empty should return {}, got %q", rl.String())
+		}
+	})
+
+	t.Run("with content", func(t *testing.T) {
+		rl := ResultLogs{"key": "value"}
+		s := rl.String()
+		if len(s) == 0 || s[0] != '{' {
+			t.Errorf("should start with {, got %q", s)
+		}
+	})
+}
+
+// --- Concurrent access safety ---
+
+func TestConcurrentToolsFor(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+	done := make(chan struct{})
+
+	for range 10 {
+		go func() {
+			for range 100 {
+				_ = r.ToolsFor(ctx)
+			}
+			done <- struct{}{}
+		}()
+	}
+	for range 10 {
+		<-done
+	}
+}
+
+func TestConcurrentInvoke(t *testing.T) {
+	r := newTestRegistry()
+	ctx := context.Background()
+	done := make(chan struct{})
+
+	for range 10 {
+		go func() {
+			for range 100 {
+				_, _ = r.Invoke(ctx, ToolNameFetch, nil)
+			}
+			done <- struct{}{}
+		}()
+	}
+	for range 10 {
+		<-done
+	}
+}

--- a/pkg/web/api/handle_platform.go
+++ b/pkg/web/api/handle_platform.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/liut/morign/pkg/models/aigc"
 	"github.com/liut/morign/pkg/models/channel"
+	"github.com/liut/morign/pkg/models/mcps"
 	"github.com/liut/morign/pkg/services/channels"
 	"github.com/liut/morign/pkg/services/channels/feishu"
 	"github.com/liut/morign/pkg/services/channels/wecom"
@@ -82,12 +83,28 @@ func InitChannels(r chi.Router, preset *aigc.Preset, sto stores.Storage, llmClie
 			slog.Info("channel: HTTP routes registered", "name", name, "path", callbackPath)
 		}
 
+		// 注册频道专属 MCP Server
+		for _, mcpCfg := range cfg.MCPServers {
+			sb := mcps.ServerBasic{
+				Name:       mcpCfg.Name,
+				URL:        mcpCfg.URL,
+				TransType:  mcpCfg.TransType,
+				HeaderCate: mcpCfg.HeaderCate,
+				Channel:    p.Name(),
+			}
+			if err := chandler.toolreg.AddServer(context.Background(), &sb); err != nil {
+				slog.Warn("channel: MCP server init failed", "channel", p.Name(), "server", mcpCfg.Name, "err", err)
+			}
+		}
+
 		// Use name + mode as unique key to support multiple instances of same channel type
 		key := name
 		if cfg.Mode != "" {
 			key = name + "-" + cfg.Mode
 		}
-		channels.TrackChannel(key, p)
+		channels.TrackChannel(key, p, func() {
+			chandler.toolreg.RemoveChannelTools(p.Name())
+		})
 		slog.Info("channel: started", "name", name, "mode", cfg.Mode, "key", key)
 	}
 
@@ -118,6 +135,8 @@ func (chh *channelHandler) MessageHandler(p channel.Channel, msg *channel.Messag
 	} else {
 		logger().Infow("not found user", "userID", msg.UserID, "err", err)
 	}
+
+	ctx = mcps.ContextWithChannel(ctx, p.Name())
 
 	// Check for commands at the beginning of content
 	if cmd := DetectCommand(msg.Content); cmd.Name != "" {


### PR DESCRIPTION
Support per-channel MCP server configuration via preset. Channel-scoped tools are only visible within their channel context. Global MCP servers continue to work as before.

- Add ServerBasic.Channel field to distinguish global vs channel servers
- Add ChannelConfig.MCPServers for preset YAML configuration
- Add ContextWithChannel/ChannelFromContext for channel context plumbing
- Add channelToolSet for per-channel tool/invoker isolation
- Unify AddServer to route by server.Channel
- Add onStop callbacks to channels registry for MCP cleanup
- Add ChannelServerStatuses for health query